### PR TITLE
chore: update version to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-01-14
+
+### Patch Changes
+
+- **Version Update**: Updated to version 2.0.2
+- **Documentation**: Updated all documentation to reflect new version
+
 ## [2.0.1] - 2026-01-14
 
 ### Patch Changes

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ This document provides migration instructions for upgrading between major versio
 
 ## Table of Contents
 
+- [v2.0.1 → v2.0.2](#v201---v202)
 - [v2.0.0 → v2.0.1](#v200---v201)
 - [v1.9.30 → v2.0.0](#v1930---v200)
 - [v1.9.29 → v1.9.30](#v1929---v1930)
@@ -37,6 +38,12 @@ This document provides migration instructions for upgrading between major versio
 - [v1.8.0 → v1.9.0](#v180---v190)
 - [v1.9.0 → v2.0.0](#v190---v200) (Future)
 - [v1.7.0 → v1.8.0](#v170---v180)
+
+## v2.0.1 → v2.0.2
+
+### Changes
+
+- Documentation updates to reflect new version
 
 ## v2.0.0 → v2.0.1
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **npm i ngxsmk-datepicker**
 
-> **Stable Version**: `2.0.1` is the current stable release. For production use, install the latest version from npm.
+> **Stable Version**: `2.0.2` is the current stable release. For production use, install the latest version from npm.
 > 
 > ⚠️ **Warning**: Version `1.9.26` contains broken styles. If you are using `1.9.26`, please upgrade to `1.9.28` or downgrade to `1.9.25` immediately.
 
@@ -126,7 +126,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.0.1
+npm install ngxsmk-datepicker@2.0.2
 ```
 
 ## **Usage**

--- a/docs/SIGNAL_FORMS_VALIDATION.md
+++ b/docs/SIGNAL_FORMS_VALIDATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Starting from version 2.0.1, `ngxsmk-datepicker` fully supports Angular 21's Signal Forms validation, including schema-based validation with the `required()` function and other validators.
+Starting from version 2.0.2, `ngxsmk-datepicker` fully supports Angular 21's Signal Forms validation, including schema-based validation with the `required()` function and other validators.
 
 ## Issue Reference
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {

--- a/projects/demo-app/src/app/app.html
+++ b/projects/demo-app/src/app/app.html
@@ -25,7 +25,7 @@
           <div class="logo-content">
             <span class="logo-text">ngxsmk-datepicker</span>
             <div class="logo-meta">
-              <span class="logo-version">v2.0.1</span>
+              <span class="logo-version">v2.0.2</span>
               @if (npmDownloads() !== null) {
               <a href="https://www.npmjs.com/package/ngxsmk-datepicker" target="_blank" class="npm-downloads"
                 title="Monthly downloads on npm" rel="noopener noreferrer">
@@ -187,7 +187,7 @@
       <div class="hero-content">
         <h1 class="hero-title">ngxsmk-datepicker</h1>
         <p class="hero-tagline">{{ t().heroTagline }}</p>
-        <p class="hero-version">(v2.0.1)</p>
+        <p class="hero-version">(v2.0.2)</p>
         <p class="hero-description">{{ t().heroDescription }}</p>
         <div class="hero-buttons">
           <a href="#installation" (click)="scrollToSection($event, 'installation')" class="hero-button primary">{{
@@ -528,7 +528,7 @@
           <p class="info-note"><strong>{{ t().note }}</strong> {{ t().thisFeatureRequiresAngular21 }}</p>
 
           <div class="example-demo">
-            <h4 class="subsection-title">Live Demo (v2.0.1+)</h4>
+            <h4 class="subsection-title">Live Demo (v2.0.2+)</h4>
             <p style="margin-bottom: 1rem; font-size: 0.875rem; color: var(--text-secondary);">
               This demo uses a mock Signal Form Field that mimics Angular 21's FieldTree structure.
               The datepicker automatically resolves the value, disabled status, and required state.

--- a/projects/demo-app/src/app/app.ts
+++ b/projects/demo-app/src/app/app.ts
@@ -323,7 +323,7 @@ export class App implements OnInit, OnDestroy, AfterViewInit {
   public signalDate = signal<DatepickerValue>(null);
 
   /**
-   * Mock Signal Form Field (v2.0.1+)
+   * Mock Signal Form Field (v2.0.2+)
    * Demonstrates a signal that has field properties attached to it.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/projects/ngxsmk-datepicker/README.md
+++ b/projects/ngxsmk-datepicker/README.md
@@ -7,7 +7,7 @@
 
 **npm i ngxsmk-datepicker**
 
-> **Stable Version**: `2.0.1` is the current stable release. For production use, install the latest version from npm.
+> **Stable Version**: `2.0.2` is the current stable release. For production use, install the latest version from npm.
 > 
 > ⚠️ **Warning**: Version `1.9.26` contains broken styles. If you are using `1.9.26`, please upgrade to `1.9.28` or downgrade to `1.9.25` immediately.
 

--- a/projects/ngxsmk-datepicker/docs/API.md
+++ b/projects/ngxsmk-datepicker/docs/API.md
@@ -2180,7 +2180,7 @@ type DateInput =
 ```
 
 
-### SignalFormField (v2.0.1+)
+### SignalFormField (v2.0.2+)
 
 **Status**: Stable
 
@@ -2190,7 +2190,7 @@ Type representing a signal-based form field.
 type SignalFormField = any; // Compatible with Angular 21 FieldTree
 ```
 
-### SignalFormFieldConfig (v2.0.1+)
+### SignalFormFieldConfig (v2.0.2+)
 
 **Status**: Stable
 

--- a/projects/ngxsmk-datepicker/docs/signal-forms.md
+++ b/projects/ngxsmk-datepicker/docs/signal-forms.md
@@ -113,7 +113,7 @@ export class TwoWayComponent {
 }
 ```
 
-### Signal Field Resolution (v2.0.1+)
+### Signal Field Resolution (v2.0.2+)
 
 The datepicker includes a robust resolution mechanism for signal-based fields. It can handle:
 - **Direct Signals**: A signal that contains the field configuration.

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.linkedin.com/in/sachindilshan/"


### PR DESCRIPTION
## Summary
Updated version from 2.0.1 to 2.0.2 across all project files and documentation.

## Changes
- Updated version in root `package.json` and `projects/ngxsmk-datepicker/package.json`
- Updated version references in `README.md` and `projects/ngxsmk-datepicker/README.md`
- Added new changelog entry for v2.0.2 in `CHANGELOG.md`
- Updated migration guide in `MIGRATION.md` to include v2.0.1 → v2.0.2 path
- Updated API documentation version references in `projects/ngxsmk-datepicker/docs/API.md`
- Updated Signal Forms documentation version references in `projects/ngxsmk-datepicker/docs/signal-forms.md`
- Updated demo app version displays in `projects/demo-app/src/app/app.html` and `projects/demo-app/src/app/app.ts`
- Updated Signal Forms validation documentation in `docs/SIGNAL_FORMS_VALIDATION.md`

## Details
This is a patch version update with documentation changes only. No breaking changes or new features were introduced.

## Testing
- Demo app is running and reflects the new version
- All version numbers have been consistently updated across the project
