### PR TITLE
chore(release): v2.0.4 - Fix Signal Forms Validation Sync & Touched State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-01-14
+
+### Patch Changes
+
+- **Version Update**: Updated to version 2.0.4
+- **Validation Fix**: Fixed issue where `[field]` validation messages were not triggering because the `touched` state was not being synced to the field. Added `markAsTouched` support to `FieldSyncService` and updated `NgxsmkDatepickerComponent` to mark the field as touched on blur and value selection.
+
 ## [2.0.3] - 2026-01-14
 
 ### Patch Changes

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ This document provides migration instructions for upgrading between major versio
 
 ## Table of Contents
 
+- [v2.0.3 → v2.0.4](#v203---v204)
 - [v2.0.2 → v2.0.3](#v202---v203)
 - [v2.0.1 → v2.0.2](#v201---v202)
 - [v2.0.0 → v2.0.1](#v200---v201)
@@ -39,6 +40,13 @@ This document provides migration instructions for upgrading between major versio
 - [v1.8.0 → v1.9.0](#v180---v190)
 - [v1.9.0 → v2.0.0](#v190---v200) (Future)
 - [v1.7.0 → v1.8.0](#v170---v180)
+
+## v2.0.3 → v2.0.4
+
+### Changes
+
+- Bug fix: Fixed `touched` state sync for Signal Forms validation.
+- No breaking changes.
 
 ## v2.0.2 → v2.0.3
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **npm i ngxsmk-datepicker**
 
-> **Stable Version**: `2.0.3` is the current stable release. For production use, install the latest version from npm.
+> **Stable Version**: `2.0.4` is the current stable release. For production use, install the latest version from npm.
 > 
 > ⚠️ **Warning**: Version `1.9.26` contains broken styles. If you are using `1.9.26`, please upgrade to `1.9.28` or downgrade to `1.9.25` immediately.
 
@@ -126,7 +126,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.0.3
+npm install ngxsmk-datepicker@2.0.4
 ```
 
 ## **Usage**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-datepicker",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.linkedin.com/in/sachindilshan/"

--- a/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts
+++ b/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts
@@ -2707,6 +2707,9 @@ export class NgxsmkDatepickerComponent implements OnInit, OnChanges, OnDestroy, 
     this.valueChange.emit(normalizedVal);
     this.onChange(normalizedVal);
     this.onTouched();
+    if (this._field) {
+      this.fieldSyncService.markAsTouched(this._field);
+    }
 
     if (!this.isInlineMode && val !== null && !this.timeOnly) {
       if (this.mode === 'single' || (this.mode === 'range' && this.startDate && this.endDate)) {
@@ -4110,6 +4113,9 @@ export class NgxsmkDatepickerComponent implements OnInit, OnChanges, OnDestroy, 
       this._focused = false;
       this.stateChanges.next();
       this.onTouched();
+      if (this._field) {
+        this.fieldSyncService.markAsTouched(this._field);
+      }
     }
 
     if (!this.allowTyping) return;

--- a/projects/ngxsmk-datepicker/src/lib/services/field-sync.service.ts
+++ b/projects/ngxsmk-datepicker/src/lib/services/field-sync.service.ts
@@ -58,6 +58,7 @@ export type SignalFormFieldConfig = {
   setValue?: (value: DatepickerValue | string) => void;
   updateValue?: (updater: () => DatepickerValue | string) => void;
   markAsDirty?: () => void;
+  markAsTouched?: () => void;
 };
 
 // Angular 21+ FieldTree compatibility - accepts any structure
@@ -579,6 +580,21 @@ export class FieldSyncService {
 
   getLastKnownValue(): DatepickerValue | undefined {
     return this._lastKnownFieldValue;
+  }
+
+  markAsTouched(fieldInput: SignalFormField | Signal<SignalFormField> | (() => unknown) | unknown): void {
+    const field = this.resolveField(fieldInput);
+    if (!field || typeof field !== 'object') {
+      return;
+    }
+
+    try {
+      if (typeof field.markAsTouched === 'function') {
+        field.markAsTouched();
+      }
+    } catch {
+      // Ignore errors when marking as touched
+    }
   }
 
   cleanup(): void {


### PR DESCRIPTION
**Summary**
This release addresses a critical bug where validation messages (like "This field is required") were not triggering for Angular Signal Forms when using the `[field]` input binding.

The root cause was that while the *value* and *dirty* states were being synced, the **touched** state was not being propagated to the form field. This prevented validation logic (which often relies on `field.touched()`) from executing.

**Key Changes**
*   **Fix Validation Sync**:
    *   Updated [FieldSyncService](cci:2://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/services/field-sync.service.ts:78:0-607:1): Added a [markAsTouched](cci:1://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/services/field-sync.service.ts:584:2-597:3) method and updated the [SignalFormFieldConfig](cci:2://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/services/field-sync.service.ts:49:0-61:2) interface to support marking fields as touched.
    *   Updated [NgxsmkDatepickerComponent](cci:2://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts:81:0-6014:1): Modified [onInputBlur](cci:1://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts:4107:2-4141:3) and [emitValue](cci:1://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts:2675:2-2718:3) to explicitly call [markAsTouched](cci:1://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/projects/ngxsmk-datepicker/src/lib/services/field-sync.service.ts:584:2-597:3) on the linked field whenever the user interacts with the component.
*   **Version Update**: Bumped version to `2.0.4` in root and library [package.json](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/package.json:0:0-0:0).
*   **Documentation**: Updated [CHANGELOG.md](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/CHANGELOG.md:0:0-0:0), [MIGRATION.md](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/MIGRATION.md:0:0-0:0), and [README.md](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/README.md:0:0-0:0) to reflect the new version and fix.

**Verification**
*   ✅ Library build (`npm run build:optimized`) passed.
*   ✅ Demo app build (`npm run build:demo`) passed.
*   ✅ Confirmed that interacting with the datepicker (blurring or selecting a value) now correctly marks the connected Signal Form field as touched.