### PR TITLE
fix: resolve TypeScript type declarations not found error (v2.0.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.11] - 2026-02-05
+
+### Fixed
+
+- **TypeScript Type Declarations**: Fixed "Could not find a declaration file for module 'ngxsmk-datepicker'" error
+  - Added proper `exports` field in package.json with correct type declaration path
+  - Configured exports to point to `index.d.ts` for TypeScript module resolution
+  - Ensures compatibility with modern Node.js and TypeScript module resolution strategies
+
 ## [2.0.10] - 2026-02-05
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -66,8 +66,8 @@ npm install ngxsmk-datepicker@2.0.8
 
 ### Changes
 
-- **Version Update**: Updated to version 2.0.7
-- **Stable Release**: Version 2.0.7 is the current stable version
+- **Version Update**: Updated to version 2.0.11
+- **Stable Release**: Version 2.0.11 is the current stable version
 - No breaking changes.
 
 ### Migration Steps

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.0.10` is live! This version includes critical bug fixes for infinite recursion, timezone handling, and build optimizations.
+> **Stable Release**: `v2.0.11` is live! This version includes critical bug fixes for TypeScript declarations and type resolution.
 
 ---
 
@@ -134,7 +134,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.0.10
+npm install ngxsmk-datepicker@2.0.11
 ```
 
 ## **Usage**

--- a/docs/BUNDLE_SIZE_REPORT.md
+++ b/docs/BUNDLE_SIZE_REPORT.md
@@ -414,7 +414,7 @@ Track bundle size across versions:
 
 ### Final Recommendations
 
-**Immediate (v2.0.10)**:
+**Immediate (v2.0.11)**:
 
 1. Remove documentation assets from npm package (66% package size reduction)
 2. Update package.json files whitelist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-datepicker",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "MIT",
       "dependencies": {
         "@tokiforge/angular": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {

--- a/projects/ngxsmk-datepicker/README.md
+++ b/projects/ngxsmk-datepicker/README.md
@@ -28,7 +28,7 @@
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.0.10` is live! This version includes critical bug fixes for infinite recursion, timezone handling, and build optimizations.
+> **Stable Release**: `v2.0.11` is live! This version includes critical bug fixes for TypeScript declarations and type resolution.
 
 ---
 
@@ -135,7 +135,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 
 Install the package using npm:
 
-    npm install ngxsmk-datepicker@2.0.10
+    npm install ngxsmk-datepicker@2.0.11
 
 ## **Usage**
 
@@ -559,7 +559,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.0.10 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.0.11 now features **full localization synchronization** for:
 
 - 🇺🇸 English (`en`)
 - 🇩🇪 German (`de`)

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.linkedin.com/in/sachindilshan/"
@@ -80,6 +80,12 @@
     "npm": ">=10.0.0"
   },
   "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "esm2022": "./esm2022/ngxsmk-datepicker.mjs",
+      "es2022": "./fesm2022/ngxsmk-datepicker.mjs",
+      "default": "./fesm2022/ngxsmk-datepicker.mjs"
+    },
     "./styles/*": {
       "default": "./styles/*"
     }


### PR DESCRIPTION
## Description

Fixes #183 - Resolves "Could not find a declaration file for module 'ngxsmk-datepicker'" error by properly configuring the package exports field.

## Changes Made

### Type Declaration Fix
- Added proper `exports` field in `package.json` with main entry point (`.`)
- Configured `types` path to point to `./index.d.ts`
- Added ES module paths (`esm2022`, `es2022`, `default`) for proper module resolution
- Ensures compatibility with modern Node.js and TypeScript module resolution strategies

### Version Update
- Bumped version from `2.0.10` to `2.0.11`
- Updated all package.json files (root and library)
- Updated package-lock.json

### Documentation Updates
- Updated README.md with new stable version notice
- Updated CHANGELOG.md with 2.0.11 release notes
- Updated MIGRATION.md with current stable version
- Updated installation instructions across all documentation
- Updated BUNDLE_SIZE_REPORT.md version references

## Root Cause

The `exports` field was missing the main entry point configuration. Modern TypeScript and Node.js use the `exports` field for module resolution, and without the main entry (`.`), TypeScript couldn't locate the type declaration files even though they existed in the package.

## Testing

- ✅ Package builds successfully
- ✅ Type declarations are properly resolved
- ✅ No breaking changes introduced

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist

- [x] Version number updated in all package.json files
- [x] CHANGELOG.md updated with release notes
- [x] Documentation updated to reflect changes
- [x] No breaking changes