### PR TITLE
chore(release): v2.1.0 - Fix package configuration and TypeScript declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.11] - 2026-02-05
+## [2.1.0] - 2026-02-05
 
 ### Fixed
 
-- **TypeScript Type Declarations**: Fixed "Could not find a declaration file for module 'ngxsmk-datepicker'" error
+- **Package Configuration**: Corrected TypeScript declaration paths in package.json
+  - Updated `types` and `typings` fields to point to `types/ngxsmk-datepicker.d.ts` instead of non-existent `index.d.ts`
+  - Simplified `exports` field to match v2.0.9 format, removing unnecessary module export configurations
+  - Removed disallowed `esm2022` property from package.json
+  - Ensures proper TypeScript module resolution in consuming applications
+
+### Changed
+
+- **Package Distribution**: Streamlined package exports configuration for better compatibility
+  - Aligned exports structure with stable v2.0.9 format
+  - Removed redundant module resolution entries for cleaner package.json
+
+### Important Notice
+
+⚠️ **Versions 2.0.10 and 2.0.11 have been unpublished from npm** due to critical package configuration issues that prevented proper TypeScript module resolution. All users should upgrade to v2.1.0 or later.
+
+## [2.0.11] - 2026-02-05 [BROKEN - UNPUBLISHED]
+
+**⚠️ This version has been unpublished from npm due to incorrect package configuration. Use v2.1.0 instead.**
+
+### Fixed
+
+- **TypeScript Type Declarations**: Attempted to fix "Could not find a declaration file for module 'ngxsmk-datepicker'" error
   - Added proper `exports` field in package.json with correct type declaration path
   - Configured exports to point to `index.d.ts` for TypeScript module resolution
-  - Ensures compatibility with modern Node.js and TypeScript module resolution strategies
+  - **Note**: This fix was incomplete and the version has been replaced by v2.1.0
 
-## [2.0.10] - 2026-02-05
+## [2.0.10] - 2026-02-05 [BROKEN - UNPUBLISHED]
+
+**⚠️ This version has been unpublished from npm due to incorrect package configuration. Use v2.1.0 instead.**
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ This document provides migration instructions for upgrading between major versio
 
 ## Table of Contents
 
+- [v2.0.11 → v2.1.0](#v2011---v210)
 - [v2.0.6 → v2.0.7](#v206---v207)
 - [v2.0.5 → v2.0.6](#v205---v206)
 - [v2.0.4 → v2.0.5](#v204---v205)
@@ -44,6 +45,44 @@ This document provides migration instructions for upgrading between major versio
 - [v1.9.0 → v2.0.0](#v190---v200) (Future)
 - [v1.7.0 → v1.8.0](#v170---v180)
 
+## v2.0.11 → v2.1.0
+
+### ⚠️ CRITICAL NOTICE
+
+**Versions 2.0.10 and 2.0.11 are broken and should NOT be used.**
+
+These versions have critical package configuration issues that prevent proper TypeScript module resolution. If you have installed either of these versions, please upgrade to v2.1.0 immediately.
+
+### Changes
+
+- **Package Fixes**: Corrected TypeScript declaration paths and package configuration
+  - Fixed `types` and `typings` fields to point to the correct location: `types/ngxsmk-datepicker.d.ts`
+  - Simplified exports configuration to match stable v2.0.9 format
+  - Removed disallowed `esm2022` property from package.json
+- **No Breaking Changes**: This is a minor version update with package configuration improvements
+- **Recommended Update**: All v2.0.x users should update to v2.1.0 for proper TypeScript support
+- **Skip 2.0.10 & 2.0.11**: These versions have been unpublished from npm due to broken package configuration
+
+### Migration Steps
+
+Update your package.json to use the new version:
+
+```bash
+npm install ngxsmk-datepicker@2.1.0
+```
+
+**No code changes required.** This update only fixes package configuration issues that were preventing proper TypeScript declaration file resolution.
+
+### What's Fixed
+
+If you were experiencing the following error:
+
+```
+Could not find a declaration file for module 'ngxsmk-datepicker'
+```
+
+This is now resolved in v2.1.0. The package now correctly points to its TypeScript declaration files.
+
 ## v2.0.7 → v2.0.8
 
 ### Changes
@@ -66,8 +105,8 @@ npm install ngxsmk-datepicker@2.0.8
 
 ### Changes
 
-- **Version Update**: Updated to version 2.0.11
-- **Stable Release**: Version 2.0.11 is the current stable version
+- **Version Update**: Updated to version 2.0.7
+- **Stable Release**: Version 2.1.0 is the current stable version
 - No breaking changes.
 
 ### Migration Steps

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.0.11` is live! This version includes critical bug fixes for TypeScript declarations and type resolution.
+> **Stable Release**: `v2.1.0` is live! This version includes critical bug fixes for TypeScript declarations and type resolution.
+>
+> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.1.0 or later.
 
 ---
 
@@ -134,7 +136,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.0.11
+npm install ngxsmk-datepicker@2.1.0
 ```
 
 ## **Usage**
@@ -560,7 +562,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.0.9 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.1.0 now features **full localization synchronization** for:
 
 - �� English (`en`)
 - �� German (`de`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-datepicker",
-      "version": "2.0.11",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@tokiforge/angular": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {

--- a/projects/ngxsmk-datepicker/README.md
+++ b/projects/ngxsmk-datepicker/README.md
@@ -28,7 +28,9 @@
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.0.11` is live! This version includes critical bug fixes for TypeScript declarations and type resolution.
+> **Stable Release**: `v2.1.0` is live! This version includes critical bug fixes for TypeScript declarations and type resolution.
+>
+> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.1.0 or later.
 
 ---
 
@@ -135,7 +137,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 
 Install the package using npm:
 
-    npm install ngxsmk-datepicker@2.0.11
+    npm install ngxsmk-datepicker@2.1.0
 
 ## **Usage**
 
@@ -559,7 +561,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.0.11 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.1.0 now features **full localization synchronization** for:
 
 - 🇺🇸 English (`en`)
 - 🇩🇪 German (`de`)

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.linkedin.com/in/sachindilshan/"
@@ -28,9 +28,8 @@
   "main": "fesm2022/ngxsmk-datepicker.mjs",
   "module": "fesm2022/ngxsmk-datepicker.mjs",
   "es2022": "fesm2022/ngxsmk-datepicker.mjs",
-  "esm2022": "fesm2022/ngxsmk-datepicker.mjs",
-  "types": "index.d.ts",
-  "typings": "index.d.ts",
+  "types": "types/ngxsmk-datepicker.d.ts",
+  "typings": "types/ngxsmk-datepicker.d.ts",
   "homepage": "https://github.com/NGXSMK/ngxsmk-datepicker#readme",
   "repository": {
     "type": "git",
@@ -80,12 +79,6 @@
     "npm": ">=10.0.0"
   },
   "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "esm2022": "./esm2022/ngxsmk-datepicker.mjs",
-      "es2022": "./fesm2022/ngxsmk-datepicker.mjs",
-      "default": "./fesm2022/ngxsmk-datepicker.mjs"
-    },
     "./styles/*": {
       "default": "./styles/*"
     }


### PR DESCRIPTION
### 🎯 Summary
This release fixes critical package configuration issues that prevented proper TypeScript module resolution in versions 2.0.10 and 2.0.11. Version 2.1.0 is now the stable release.

### 🔧 Changes

**Package Configuration Fixes:**
- ✅ Fixed TypeScript declaration paths in `package.json`
  - Updated `types` and `typings` fields to point to correct location: `types/ngxsmk-datepicker.d.ts`
  - Previously pointed to non-existent `index.d.ts`
- ✅ Simplified `exports` field to match stable v2.0.9 format
  - Removed unnecessary module export configurations
  - Aligned with working configuration from previous stable version
- ✅ Removed disallowed `esm2022` property from package.json
  - Property was not allowed in current Angular package format

**Version Management:**
- 📦 Released v2.1.0-beta.0 for dev testing
- 📦 Promoted to stable v2.1.0
- ⚠️ Unpublished broken versions 2.0.10 and 2.0.11 from npm

**Documentation Updates:**
- 📝 Updated all markdown files with v2.1.0 as current stable version
- 📝 Added critical warnings about broken 2.0.10 and 2.0.11 versions
- 📝 Updated CHANGELOG.md with detailed release notes
- 📝 Updated MIGRATION.md with upgrade instructions
- 📝 Updated README.md with version information and warnings

### 🐛 Fixes
Resolves the following error users were experiencing: