### PR TITLE
feat: v2.1.4 - Enhanced Playground, 42-Day Calendar Grid, and Full i18n Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2026-02-13
+
+### Added
+
+- **Playground Enhancements**: Added new configuration options for `minDate`, `maxDate`, and `weekStart` to the interactive playground, allowing users to test boundary constraints and locale overrides.
+- **Improved Internationalization**: Added full translation support for new playground features across all 8 supported languages (English, German, Spanish, Swedish, Korean, Chinese, Japanese, and French).
+
+### Fixed
+
+- **Calendar Grid Consistency**: Ensured the calendar always generates a full 42-day (6-week) grid. This prevents layout shifts and provides a more stable UI when navigating between months with different numbers of days.
+- **Locale-Specific Week Starts**: Fixed issues with manual `weekStart` overrides and locale-dependent first day of week calculations, ensuring accurate calendar generation across diverse cultural settings.
+
 ## [2.1.3] - 2026-02-11
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ This document provides migration instructions for upgrading between major versio
 
 ## Table of Contents
 
+- [v2.1.3 → v2.1.4](#v213---v214)
 - [v2.1.2 → v2.1.3](#v212---v213)
 - [v2.1.1 → v2.1.2](#v211---v212)
 - [v2.0.11 → v2.1.1](#v2011---v211)
@@ -46,6 +47,23 @@ This document provides migration instructions for upgrading between major versio
 - [v1.8.0 → v1.9.0](#v180---v190)
 - [v1.9.0 → v2.0.0](#v190---v200) (Future)
 - [v1.7.0 → v1.8.0](#v170---v180)
+
+## v2.1.3 → v2.1.4
+
+### Changes
+
+- **Version Update**: Updated to version 2.1.4.
+- **Improved Calendar Grid**: Calendar now always generates exactly 42 days (6 full weeks), providing layout stability during month navigation.
+- **Enhanced Playground**: New options for `minDate`, `maxDate`, and `weekStart` constraints.
+- No breaking changes.
+
+### Migration Steps
+
+No migration steps required.
+
+```bash
+npm install ngxsmk-datepicker@2.1.4
+```
 
 ## v2.1.2 → v2.1.3
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.1.3` is live! This major update introduces a significant **UI Refresh (Border Detox)**, **Mobile Stability** improvements, and fixes for circular dependencies.
+> **Stable Release**: `v2.1.4` is live! This major update introduces a significant **UI Refresh (Border Detox)**, **Mobile Stability** improvements, and fixes for circular dependencies.
 >
-> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.1.3 or later.
+> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.1.4 or later.
 
 ---
 
@@ -136,7 +136,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.1.3
+npm install ngxsmk-datepicker@2.1.4
 ```
 
 ## **Usage**
@@ -562,7 +562,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.1.3 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.1.4 now features **full localization synchronization** for:
 
 - �� English (`en`)
 - �� German (`de`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-datepicker-workspace",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-datepicker-workspace",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@tokiforge/angular": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker-workspace",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {

--- a/projects/demo-app/src/app/i18n/translations.ts
+++ b/projects/demo-app/src/app/i18n/translations.ts
@@ -27,7 +27,7 @@ export const translations = {
             playground: 'Playground'
         },
         home: {
-            heroBadge: 'New v2.1.3 Stability',
+            heroBadge: 'New v2.1.4 Stability',
             heroTitle: 'The Best Open-Source',
             heroSubtitle: 'Angular DatePicker',
             heroLead: 'The most powerful, lightweight, and accessible datepicker for modern Angular projects. Seamless Signal-based state, Zoneless architecture, and infinite customization.',
@@ -100,7 +100,15 @@ export const translations = {
             vertical: 'Vertical',
             auto: 'Auto',
             lightTheme: 'Light Theme',
-            darkTheme: 'Dark Theme'
+            darkTheme: 'Dark Theme',
+            positioningLimits: 'Positioning & Limits',
+            enableMinDate: 'Enable Min Date (7 days ago)',
+            enableMaxDate: 'Enable Max Date (7 days ahead)',
+            weekStart: 'Week Start',
+            autoLocale: 'Auto (Locale)',
+            sunday: 'Sunday',
+            monday: 'Monday',
+            saturday: 'Saturday'
         },
         installation: {
             title: 'Installation',
@@ -308,7 +316,7 @@ export const translations = {
             playground: 'Spielplatz'
         },
         home: {
-            heroBadge: 'Neu v2.1.3 Stabilität',
+            heroBadge: 'Neu v2.1.4 Stabilität',
             heroTitle: 'Der beste Open-Source',
             heroSubtitle: 'Angular DatePicker',
             heroLead: 'Der leistungsstärkste, leichteste und barrierefreieste Datepicker für moderne Angular-Projekte. Nahtloser Signal-basierter Status, Zoneless-Architektur und unendliche Anpassungsmöglichkeiten.',
@@ -381,7 +389,15 @@ export const translations = {
             vertical: 'Vertikal',
             auto: 'Auto',
             lightTheme: 'Helles Thema',
-            darkTheme: 'Dunkles Thema'
+            darkTheme: 'Dunkles Thema',
+            positioningLimits: 'Positionierung & Limits',
+            enableMinDate: 'Min. Datum aktivieren (-7 Tage)',
+            enableMaxDate: 'Max. Datum aktivieren (+7 Tage)',
+            weekStart: 'Wochenstart',
+            autoLocale: 'Auto (Gebietsschema)',
+            sunday: 'Sonntag',
+            monday: 'Montag',
+            saturday: 'Samstag'
         },
         installation: {
             title: 'Installation',
@@ -571,7 +587,7 @@ export const translations = {
             playground: 'Laboratorio'
         },
         home: {
-            heroBadge: 'Nuevo v2.1.3 Estabilidad',
+            heroBadge: 'Nuevo v2.1.4 Estabilidad',
             heroTitle: 'El mejor Open-Source',
             heroSubtitle: 'Angular DatePicker',
             heroLead: 'El selector de fechas más potente, ligero y accesible para proyectos modernos de Angular. Estado impecable basado en Signals, arquitectura Zoneless y personalización infinita.',
@@ -626,7 +642,15 @@ export const translations = {
             vertical: 'Vertical',
             auto: 'Auto',
             lightTheme: 'Tema claro',
-            darkTheme: 'Tema oscuro'
+            darkTheme: 'Tema oscuro',
+            positioningLimits: 'Posicionamiento y Límites',
+            enableMinDate: 'Activar fecha mínima (-7 días)',
+            enableMaxDate: 'Activar fecha máxima (+7 días)',
+            weekStart: 'Inicio de semana',
+            autoLocale: 'Auto (Localización)',
+            sunday: 'Domingo',
+            monday: 'Lunes',
+            saturday: 'Sábado'
         },
         installation: {
             title: 'Instalación',
@@ -816,7 +840,7 @@ export const translations = {
             playground: 'Lekplats'
         },
         home: {
-            heroBadge: 'Ny v2.1.3 stabilitet',
+            heroBadge: 'Ny v2.1.4 stabilitet',
             heroTitle: 'Den bästa open-source',
             heroSubtitle: 'Angular datumväljare',
             heroLead: 'Den mest kraftfulla, lätta och tillgängliga datumväljaren för moderna Angular-projekt. Sömlös signalbaserad status, zonlös arkitektur och oändlig anpassning.',
@@ -871,7 +895,15 @@ export const translations = {
             vertical: 'Vertikal',
             auto: 'Auto',
             lightTheme: 'Ljust tema',
-            darkTheme: 'Mörkt tema'
+            darkTheme: 'Mörkt tema',
+            positioningLimits: 'Positionering & gränser',
+            enableMinDate: 'Aktivera minsta datum (-7 dagar)',
+            enableMaxDate: 'Aktivera högsta datum (+7 dagar)',
+            weekStart: 'Veckostart',
+            autoLocale: 'Auto (språk)',
+            sunday: 'Söndag',
+            monday: 'Måndag',
+            saturday: 'Lördag'
         },
         installation: {
             title: 'Installation',
@@ -1061,7 +1093,7 @@ export const translations = {
             playground: '플레이그라운드'
         },
         home: {
-            heroBadge: '새로운 v2.1.3 안정성',
+            heroBadge: '새로운 v2.1.4 안정성',
             heroTitle: '최고의 오픈 소스',
             heroSubtitle: 'Angular 데이트피커',
             heroLead: '현대적인 Angular 프로젝트를 위한 가장 강력하고 가볍고 접근성이 좋은 데이트피커입니다. 원활한 Signal 기반 상태, Zoneless 아키텍처 및 무한한 커스터마이징을 제공합니다.',
@@ -1116,7 +1148,15 @@ export const translations = {
             vertical: '세로',
             auto: '자동',
             lightTheme: '라이트 테마',
-            darkTheme: '다크 테마'
+            darkTheme: '다크 테마',
+            positioningLimits: '위치 및 제한',
+            enableMinDate: '최소 날짜 활성화 (-7일)',
+            enableMaxDate: '최대 날짜 활성화 (+7일)',
+            weekStart: '주 시작일',
+            autoLocale: '자동 (로케일)',
+            sunday: '일요일',
+            monday: '월요일',
+            saturday: '토요일'
         },
         installation: {
             title: '설치',
@@ -1306,7 +1346,7 @@ export const translations = {
             playground: '演练场'
         },
         home: {
-            heroBadge: '全新 v2.1.3 稳定性',
+            heroBadge: '全新 v2.1.4 稳定性',
             heroTitle: '最佳开源',
             heroSubtitle: 'Angular 日期选择器',
             heroLead: '适用于现代 Angular 项目的功能最强大、轻量且符合无障碍标准的日期选择器。无缝的基于 Signal 的状态管理、无 Zone 架构和无限的自定义选项。',
@@ -1361,7 +1401,15 @@ export const translations = {
             vertical: '垂直',
             auto: '自动',
             lightTheme: '浅色主题',
-            darkTheme: '深色主题'
+            darkTheme: '深色主题',
+            positioningLimits: '位置与限制',
+            enableMinDate: '启用最小日期 (-7天)',
+            enableMaxDate: '启用最大日期 (+7天)',
+            weekStart: '起始星期',
+            autoLocale: '自动 (区域设置)',
+            sunday: '星期日',
+            monday: '星期一',
+            saturday: '星期六'
         },
         installation: {
             title: '安装',
@@ -1551,7 +1599,7 @@ export const translations = {
             playground: 'プレイグラウンド'
         },
         home: {
-            heroBadge: '新しい v2.1.3 の安定性',
+            heroBadge: '新しい v2.1.4 の安定性',
             heroTitle: '最高のオープンソース',
             heroSubtitle: 'Angular デートピッカー',
             heroLead: '現代のAngularプロジェクトのための、最も強力で軽量、かつアクセシビリティに優れたデートピッカーです。シームレスなSignalベースの状態、Zonelessアーキテクチャ、 そして 無限のカスタマイズを提供します。',
@@ -1606,7 +1654,15 @@ export const translations = {
             vertical: '垂直',
             auto: '自動',
             lightTheme: 'ライトテーマ',
-            darkTheme: 'ダークテーマ'
+            darkTheme: 'ダークテーマ',
+            positioningLimits: '配置と制限',
+            enableMinDate: '最小日付を有効にする (-7日)',
+            enableMaxDate: '最大日付を有効にする (+7日)',
+            weekStart: '週の開始日',
+            autoLocale: '自動 (ロケール)',
+            sunday: '日曜日',
+            monday: '月曜日',
+            saturday: '土曜日'
         },
         installation: {
             title: 'インストール',
@@ -1796,7 +1852,7 @@ export const translations = {
             playground: 'Playground'
         },
         home: {
-            heroBadge: 'Nouvelle stabilité v2.1.3',
+            heroBadge: 'Nouvelle stabilité v2.1.4',
             heroTitle: 'Le meilleur Open-Source',
             heroSubtitle: 'Angular DatePicker',
             heroLead: 'Le sélecteur de date le plus puissant, léger et accessible pour les projets Angular modernes. État fluide basé sur les Signals, architecture Zoneless et personnalisation infinie.',
@@ -1851,7 +1907,15 @@ export const translations = {
             vertical: 'Vertical',
             auto: 'Auto',
             lightTheme: 'Thème clair',
-            darkTheme: 'Thème sombre'
+            darkTheme: 'Thème sombre',
+            positioningLimits: 'Positionnement & Limites',
+            enableMinDate: 'Activer la date minimale (-7 jours)',
+            enableMaxDate: 'Activer la date maximale (+7 jours)',
+            weekStart: 'Début de semaine',
+            autoLocale: 'Auto (Paramètres régionaux)',
+            sunday: 'Dimanche',
+            monday: 'Lundi',
+            saturday: 'Samedi'
         },
         installation: {
             title: 'Installation',

--- a/projects/demo-app/src/app/pages/home/home.component.ts
+++ b/projects/demo-app/src/app/pages/home/home.component.ts
@@ -126,7 +126,7 @@ import { I18nService } from '../../i18n/i18n.service';
             <p>{{ i18n.t().common.installToday }}</p>
           </div>
           <div class="cta-code">
-            <pre><code>npm install ngxsmk-datepicker@2.1.3</code></pre>
+            <pre><code>npm install ngxsmk-datepicker@2.1.4</code></pre>
           </div>
         </div>
       </section>

--- a/projects/demo-app/src/app/pages/playground/playground.component.ts
+++ b/projects/demo-app/src/app/pages/playground/playground.component.ts
@@ -105,13 +105,34 @@ import { I18nService } from '../../i18n/i18n.service';
           </div>
 
           <div class="config-group">
-            <span class="group-label">Positioning</span>
+            <span class="group-label">{{ i18n.t().playground.positioningLimits }}</span>
             <div class="config-item">
               <label for="align">Alignment</label>
               <select id="align" [(ngModel)]="align">
                 <option value="left">Left</option>
                 <option value="right">Right</option>
                 <option value="center">Center</option>
+              </select>
+            </div>
+            <div class="config-item">
+              <label class="checkbox-label">
+                <input type="checkbox" [(ngModel)]="enableMinDate">
+                {{ i18n.t().playground.enableMinDate }}
+              </label>
+            </div>
+            <div class="config-item">
+              <label class="checkbox-label">
+                <input type="checkbox" [(ngModel)]="enableMaxDate">
+                {{ i18n.t().playground.enableMaxDate }}
+              </label>
+            </div>
+            <div class="config-item">
+              <label for="weekStart">{{ i18n.t().playground.weekStart }}</label>
+              <select id="weekStart" [(ngModel)]="weekStart">
+                <option [ngValue]="null">{{ i18n.t().playground.autoLocale }}</option>
+                <option [ngValue]="0">{{ i18n.t().playground.sunday }} (0)</option>
+                <option [ngValue]="1">{{ i18n.t().playground.monday }} (1)</option>
+                <option [ngValue]="6">{{ i18n.t().playground.saturday }} (6)</option>
               </select>
             </div>
           </div>
@@ -164,6 +185,9 @@ import { I18nService } from '../../i18n/i18n.service';
               [useNativePicker]="useNativePicker"
               [dateTemplate]="useCustomTemplate ? customDateCell : null"
               [align]="align"
+              [weekStart]="weekStart"
+              [minDate]="effectiveMinDate"
+              [maxDate]="effectiveMaxDate"
               [holidayProvider]="useHolidayProvider ? holidayProvider : null"
               [(ngModel)]="value">
             </ngxsmk-datepicker>
@@ -378,6 +402,22 @@ export class PlaygroundComponent {
   weekStart: number | null = null;
   value: Date | { start: Date; end: Date } | Date[] | null = null;
   useHolidayProvider = false;
+  enableMinDate = false;
+  enableMaxDate = false;
+
+  get effectiveMinDate(): Date | null {
+    if (!this.enableMinDate) return null;
+    const d = new Date();
+    d.setDate(d.getDate() - 7);
+    return d;
+  }
+
+  get effectiveMaxDate(): Date | null {
+    if (!this.enableMaxDate) return null;
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return d;
+  }
 
   holidayProvider: HolidayProvider = {
     isHoliday(date: Date): boolean {
@@ -410,6 +450,8 @@ export class PlaygroundComponent {
     this.value = null;
     this.useCustomTemplate = false;
     this.useHolidayProvider = false;
+    this.enableMinDate = false;
+    this.enableMaxDate = false;
     this.align = 'left';
   }
 }

--- a/projects/ngxsmk-datepicker/README.md
+++ b/projects/ngxsmk-datepicker/README.md
@@ -28,9 +28,9 @@
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.1.3` is live! This major update introduces a significant **UI Refresh (Border Detox)**, **Mobile Stability** improvements, and fixes for circular dependencies.
+> **Stable Release**: `v2.1.4` is live! This major update introduces a significant **UI Refresh (Border Detox)**, **Mobile Stability** improvements, and fixes for circular dependencies.
 >
-> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.1.3 or later.
+> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.1.4 or later.
 
 ---
 
@@ -561,7 +561,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.1.3 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.1.4 now features **full localization synchronization** for:
 
 - 🇺🇸 English (`en`)
 - 🇩🇪 German (`de`)
@@ -654,7 +654,7 @@ This library has been optimized for maximum performance:
 
 ## **🐛 Bug Fixes & Improvements**
 
-### **Critical Updates in v2.1.3:**
+### **Critical Updates in v2.1.4:**
 
 - ✅ **UI Refresh**: "Border Detox" for cleaner, modern aesthetics
 - ✅ **Mobile Stability**: Ghost click protection and better portaling logic

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.linkedin.com/in/sachindilshan/"

--- a/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts
+++ b/projects/ngxsmk-datepicker/src/lib/ngxsmk-datepicker.ts
@@ -1545,6 +1545,8 @@ export class NgxsmkDatepickerComponent
   @Input() set minDate(value: DateInput | null) {
     this._minDate = this._normalizeDate(value);
     this._updateMemoSignals();
+    this._invalidateMemoCache();
+    this.cdr.markForCheck();
   }
   get minDate(): DateInput | null {
     return this._minDate;
@@ -1554,6 +1556,8 @@ export class NgxsmkDatepickerComponent
   @Input() set maxDate(value: DateInput | null) {
     this._maxDate = this._normalizeDate(value);
     this._updateMemoSignals();
+    this._invalidateMemoCache();
+    this.cdr.markForCheck();
   }
   get maxDate(): DateInput | null {
     return this._maxDate;
@@ -1941,6 +1945,7 @@ export class NgxsmkDatepickerComponent
     return {
       month: this._currentMonthSignal(),
       year: this._currentYearSignal(),
+      firstDayOfWeek: this.firstDayOfWeek,
       holidayProvider: this._holidayProviderSignal(),
       disabledState: this._disabledStateSignal(),
     };
@@ -4333,9 +4338,10 @@ export class NgxsmkDatepickerComponent
         this.calendarGenerationService.clearCache();
         this.initializeTranslations();
         this.generateLocaleData();
-        // Don't regenerate calendar immediately after locale change
-        // Let the component handle this lazily when needed
-        needsChangeDetection = false;
+        this._invalidateMemoCache();
+        // Regenerate calendar immediately after locale change to prevent day-of-week shift
+        this.generateCalendar();
+        needsChangeDetection = true;
       } else {
         needsChangeDetection = true;
       }
@@ -4356,12 +4362,13 @@ export class NgxsmkDatepickerComponent
           this.calendarGenerationService.clearCache();
         }
         this.generateLocaleData();
-        // Don't regenerate calendar immediately after weekStart change
-        // Let the component handle this lazily when needed
+        this._invalidateMemoCache();
+        // Regenerate calendar immediately after weekStart change to prevent day-of-week shift
+        this.generateCalendar();
         if (changes['weekStart']) {
           this.clearActiveTimeouts();
         }
-        needsChangeDetection = false;
+        needsChangeDetection = true;
       } else {
         needsChangeDetection = true;
       }

--- a/projects/ngxsmk-datepicker/src/lib/services/calendar-generation.service.ts
+++ b/projects/ngxsmk-datepicker/src/lib/services/calendar-generation.service.ts
@@ -21,7 +21,7 @@ export class CalendarGenerationService {
     firstDayOfWeek: number,
     normalizeDateFn: (date: DateInput | null) => Date | null
   ): (Date | null)[] {
-    const cacheKey = `${year}-${month}`;
+    const cacheKey = `${year}-${month}-${firstDayOfWeek}`;
     let days = this.monthCache.get(cacheKey);
 
     if (!days) {
@@ -83,7 +83,7 @@ export class CalendarGenerationService {
     ];
 
     for (const { year, month } of monthsToPreload) {
-      const cacheKey = `${year}-${month}`;
+      const cacheKey = `${year}-${month}-${firstDayOfWeek}`;
       if (!this.monthCache.has(cacheKey)) {
         const days = this._generateMonthDays(year, month, firstDayOfWeek, normalizeDateFn);
         if (this.monthCache.size >= this.MAX_CACHE_SIZE) {
@@ -132,6 +132,16 @@ export class CalendarGenerationService {
     // Add days from current month
     for (let i = 1; i <= lastDayOfMonth.getDate(); i++) {
       days.push(normalizeDateFn(new Date(year, month, i)));
+    }
+
+    // Add days from next month to reach exactly 42 days (6 weeks)
+    // This ensures a consistent calendar grid height and prevents layout shifts
+    const nextMonth = month === 11 ? 0 : month + 1;
+    const nextYear = month === 11 ? year + 1 : year;
+    const remainingCells = 42 - days.length;
+
+    for (let i = 1; i <= remainingCells; i++) {
+      days.push(normalizeDateFn(new Date(nextYear, nextMonth, i)));
     }
 
     return days;


### PR DESCRIPTION
### **Description**
This PR bumps the library version to **v2.1.4** and introduces key stability improvements to the calendar layout, along with expanded configuration options in the playground for enhanced developer testing and verification.

### **🚀 Key Changes**
*   **Enhanced Playground Options**: Added interactive toggles for `minDate` (-7 days) and `maxDate` (+7 days) to test boundary constraints and validation logic in real-time.
*   **Manual Week Start**: Integrated a `weekStart` override dropdown in the playground, allowing manual selection of Sunday, Monday, or Saturday, or defaulting to Locale-based detection.
*   **Full i18n Synchronization**: Localized all new playground labels and configuration options across all **8 supported languages** (English, German, Spanish, Swedish, Korean, Chinese, Japanese, and French).
*   **Consistent 42-Day Grid**: Fixed the `CalendarGenerationService` to always generate a 6-week (42 days) grid. This prevents cumulative layout shifts (CLS) and provides a more stable UI when navigating between months with different numbers of days.
*   **Version & Docs Alignment**: Bumped version to `2.1.4` across the entire workspace and updated [README.md](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/README.md:0:0-0:0), [CHANGELOG.md](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/CHANGELOG.md:0:0-0:0), and [MIGRATION.md](cci:7://file:///d:/My%20Projects/PRODUCTION/NGXSMK/ngxsmk-datepicker/MIGRATION.md:0:0-0:0) with the latest release details.

### **🛠 Stability & Performance**
*   **Fixed**: Implementation of manual `weekStart` overrides and locale-dependent first-day-of-week calculations.
*   **Improved**: Render stability in the demo app during navigation transitions.
*   **Verified**: All build pipes and linting rules are passing.

### **🧪 Verification Results**
*   ✅ `npm run lint`: All files pass linting.
*   ✅ `npm run build:optimized`: Production library build successful.
*   ✅ `npm run build:demo`: Demo application build successful.
*   ✅ Verified in Playground: Date limits and week-start overrides work seamlessly across different locales.

---

**Note**: This version replaces `v2.1.3` as the recommended stable release.