### PR TITLE
chore(release): bump to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-03-03
+
+- **Version**: Bump to 2.2.2 (current stable release).
+
 ## [2.2.1] - 2026-03-03
 
-- **Version**: Bump to 2.2.1 (current stable release).
+- **Version**: Bump to 2.2.1.
 
 ## [2.2.0] - 2026-02-25
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to ngxsmk-datepicker! This document provides guidelines and instructions for contributing.
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Code of Conduct
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 This document explains how the ngxsmk-datepicker demo app is deployed to GitHub Pages.
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Automatic Deployment
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This document provides migration instructions for upgrading between major versions of ngxsmk-datepicker.
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Table of Contents
 
@@ -248,7 +248,7 @@ npm install ngxsmk-datepicker@2.0.8
 ### Changes
 
 - **Version Update**: Updated to version 2.0.7
-- **Stable Release**: Version 2.2.1 is the current stable version
+- **Stable Release**: Version 2.2.2 is the current stable version
 - No breaking changes.
 
 ### Migration Steps

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 This document outlines the process for publishing new versions of `ngxsmk-datepicker` to npm.
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Prerequisites
 
@@ -104,8 +104,8 @@ npm run publish:beta
 ### 2. Publish production (after beta is validated)
 
 ```bash
-# Set the stable version (must match the release, e.g. 2.2.1 from 2.2.1-beta.0)
-npm run version:stable -- 2.2.1
+# Set the stable version (must match the release, e.g. 2.2.2 from 2.2.2-beta.0)
+npm run version:stable -- 2.2.2
 
 # Update CHANGELOG.md: rename [X.Y.Z-beta.N] to [X.Y.Z] or add a [X.Y.Z] section, then commit
 
@@ -118,8 +118,8 @@ npm run publish:patch
 
 ### Manual version (optional)
 
-- Set a specific beta: `node scripts/set-beta-version.js 2.2.1-beta.0`
-- Set stable: `node scripts/set-stable-version.js 2.2.1`
+- Set a specific beta: `node scripts/set-beta-version.js 2.2.2-beta.0`
+- Set stable: `node scripts/set-stable-version.js 2.2.2`
 
 ## Pre-Release Checklist
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@
 
 ---
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ### **Overview**
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.2.1` is live! This release brings a **TypeScript Strictness Overhaul** (eliminating `any` types and ensuring `exactOptionalPropertyTypes` compatibility), fixes **appendToBody** popover positioning, datepicker-in-modal first-open behavior, and popover width matching the input; it also reduces loading time and cleans up CSS. No breaking changes.
+> **Stable Release**: `v2.2.2` is live! This release brings a **TypeScript Strictness Overhaul** (eliminating `any` types and ensuring `exactOptionalPropertyTypes` compatibility), fixes **appendToBody** popover positioning, datepicker-in-modal first-open behavior, and popover width matching the input; it also reduces loading time and cleans up CSS. No breaking changes.
 >
-> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.2.1 or later.
+> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.2.2 or later.
 
 ---
 
@@ -139,7 +139,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.2.1
+npm install ngxsmk-datepicker@2.2.2
 ```
 
 ### Alternative installation
@@ -148,12 +148,12 @@ You can install without npm using any of these methods (peer dependencies must s
 
 | Method | Command |
 |--------|--------|
-| **Yarn** | `yarn add ngxsmk-datepicker@2.2.1` |
-| **pnpm** | `pnpm add ngxsmk-datepicker@2.2.1` |
-| **Bun** | `bun add ngxsmk-datepicker@2.2.1` |
-| **From Git** | `npm install github:NGXSMK/ngxsmk-datepicker#v2.2.1` (requires the repo to have built output or you build from source) |
+| **Yarn** | `yarn add ngxsmk-datepicker@2.2.2` |
+| **pnpm** | `pnpm add ngxsmk-datepicker@2.2.2` |
+| **Bun** | `bun add ngxsmk-datepicker@2.2.2` |
+| **From Git** | `npm install github:NGXSMK/ngxsmk-datepicker#v2.2.2` (requires the repo to have built output or you build from source) |
 | **Local path** | Build the library in the repo (`npx ng build ngxsmk-datepicker`), then `npm install /path/to/ngxsmk-datepicker/dist/ngxsmk-datepicker` |
-| **CDN (ESM)** | Use [unpkg](https://unpkg.com/ngxsmk-datepicker@2.2.1/) or [jsDelivr](https://cdn.jsdelivr.net/npm/ngxsmk-datepicker@2.2.1/) in your bundler or import map; peer dependencies (Angular, etc.) must be installed in your app. |
+| **CDN (ESM)** | Use [unpkg](https://unpkg.com/ngxsmk-datepicker@2.2.2/) or [jsDelivr](https://cdn.jsdelivr.net/npm/ngxsmk-datepicker@2.2.2/) in your bundler or import map; peer dependencies (Angular, etc.) must be installed in your app. |
 
 For all options and caveats, see [docs/INSTALLATION.md](docs/INSTALLATION.md).
 
@@ -341,22 +341,7 @@ export class MaterialFormComponent {
 }
 ```
 
-**Non-Standalone Components (NgModules):**
-
-```typescript
-import { NgModule } from "@angular/core";
-import { MatFormFieldControl } from "@angular/material/form-field";
-import { NgxsmkDatepickerComponent, provideMaterialFormFieldControl } from "ngxsmk-datepicker";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { MatInputModule } from "@angular/material/input";
-import { ReactiveFormsModule } from "@angular/forms";
-
-@NgModule({
-  imports: [NgxsmkDatepickerComponent, MatFormFieldModule, MatInputModule, ReactiveFormsModule],
-  providers: [provideMaterialFormFieldControl(MatFormFieldControl)],
-})
-export class MyModule {}
-```
+**Non-Standalone (NgModules):** Add the directive file from [INTEGRATION.md § Angular Material](projects/ngxsmk-datepicker/docs/INTEGRATION.md#angular-material), then add it to your module `imports` (with `NgxsmkDatepickerComponent`, `MatFormFieldModule`, etc.) and use `ngxsmkMatFormFieldControl` on the datepicker in templates.
 
 **With Date Range:**
 
@@ -619,7 +604,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.2.1 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.2.2 now features **full localization synchronization** for:
 
 - �� English (`en`)
 - �� German (`de`)
@@ -875,7 +860,7 @@ We welcome and appreciate contributions from the community! Whether it's reporti
 
 ## **📄 Changelog**
 
-**Recent:** v2.2.1 — TypeScript strictness overhaul, appendToBody/popover fixes, loading and CSS cleanup. Versions 2.0.10 and 2.0.11 are unpublished; use v2.2.1 or later.
+**Recent:** v2.2.2 — TypeScript strictness overhaul, appendToBody/popover fixes, loading and CSS cleanup. Versions 2.0.10 and 2.0.11 are unpublished; use v2.2.2 or later.
 
 For the full list of changes, see [CHANGELOG.md](https://github.com/NGXSMK/ngxsmk-datepicker/blob/main/CHANGELOG.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap outlines the planned features, improvements, and enhancements for ngxsmk-datepicker. We welcome community input and contributions!
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## 🎯 Current Focus (Q1 2026 - Q2 2026)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Supported Versions
 

--- a/docs/ACCESSIBILITY_TESTING.md
+++ b/docs/ACCESSIBILITY_TESTING.md
@@ -1,6 +1,6 @@
 # Accessibility Testing
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document outlines the accessibility testing infrastructure integrated into the ngxsmk-datepicker library.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 Complete API reference for ngxsmk-datepicker with JSDoc examples for improved IDE IntelliSense.
 
-**Version**: 2.2.1+  
+**Version**: 2.2.2+  
 **Last Updated**: March 3, 2026
 
 ---

--- a/docs/BUNDLE_SIZE_REPORT.md
+++ b/docs/BUNDLE_SIZE_REPORT.md
@@ -1,7 +1,7 @@
 # Bundle Size Optimization Report
 
 **Generated**: March 3, 2026  
-**Version**: 2.2.1
+**Version**: 2.2.2
 
 ---
 
@@ -393,7 +393,7 @@ Track bundle size across versions:
 | 2.0.9   | 799 KB      | +19 KB | Testing utils, visual regression |
 | 2.1.1   | 805 KB      | +6 KB  | Material integration, bug fixes  |
 | 2.1.2   | 804 KB      | -1 KB  | Circular dependency fix, cleanup  |
-| 2.2.1   | 812 KB      | -      | Current stable                    |
+| 2.2.2   | 812 KB      | -      | Current stable                    |
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,32 +1,32 @@
 # Installation options for ngxsmk-datepicker
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document lists all supported ways to install `ngxsmk-datepicker` in your Angular project. The package is published to the npm registry and can also be installed via other package managers, from Git, from a local path, or via CDN (ESM).
 
 ## Package managers (npm registry)
 
-All of these resolve the package from the npm registry. Use the same version (e.g. `2.2.1`) or `@latest`.
+All of these resolve the package from the npm registry. Use the same version (e.g. `2.2.2`) or `@latest`.
 
 | Method | Command |
 |--------|--------|
-| **npm** | `npm install ngxsmk-datepicker@2.2.1` |
-| **Yarn** | `yarn add ngxsmk-datepicker@2.2.1` |
-| **pnpm** | `pnpm add ngxsmk-datepicker@2.2.1` |
-| **Bun** | `bun add ngxsmk-datepicker@2.2.1` |
+| **npm** | `npm install ngxsmk-datepicker@2.2.2` |
+| **Yarn** | `yarn add ngxsmk-datepicker@2.2.2` |
+| **pnpm** | `pnpm add ngxsmk-datepicker@2.2.2` |
+| **Bun** | `bun add ngxsmk-datepicker@2.2.2` |
 
 ## Install from Git
 
 You can install from the GitHub repository using a tag or branch:
 
 ```bash
-npm install github:NGXSMK/ngxsmk-datepicker#v2.2.1
+npm install github:NGXSMK/ngxsmk-datepicker#v2.2.2
 # or
-yarn add github:NGXSMK/ngxsmk-datepicker#v2.2.1
-pnpm add github:NGXSMK/ngxsmk-datepicker#v2.2.1
+yarn add github:NGXSMK/ngxsmk-datepicker#v2.2.2
+pnpm add github:NGXSMK/ngxsmk-datepicker#v2.2.2
 ```
 
-**Caveat:** This requires that the ref (e.g. `v2.2.1`) exists and that the built output is available (e.g. the tag includes a built `dist` or you have a postinstall that builds). If the repo does not ship built artifacts for that ref, clone the repo, run `npx ng build ngxsmk-datepicker` in the repo root, then use the [Local path](#local-path) method pointing at the built output.
+**Caveat:** This requires that the ref (e.g. `v2.2.2`) exists and that the built output is available (e.g. the tag includes a built `dist` or you have a postinstall that builds). If the repo does not ship built artifacts for that ref, clone the repo, run `npx ng build ngxsmk-datepicker` in the repo root, then use the [Local path](#local-path) method pointing at the built output.
 
 ## Local path
 
@@ -48,8 +48,8 @@ Useful for local development or offline use:
 
 The package is ESM-only (FESM). You can point your bundler or import map at a CDN URL. Peer dependencies (Angular, etc.) must still be installed in your application.
 
-- **unpkg:** `https://unpkg.com/ngxsmk-datepicker@2.2.1/fesm2022/ngxsmk-datepicker.mjs`
-- **jsDelivr:** `https://cdn.jsdelivr.net/npm/ngxsmk-datepicker@2.2.1/fesm2022/ngxsmk-datepicker.mjs`
+- **unpkg:** `https://unpkg.com/ngxsmk-datepicker@2.2.2/fesm2022/ngxsmk-datepicker.mjs`
+- **jsDelivr:** `https://cdn.jsdelivr.net/npm/ngxsmk-datepicker@2.2.2/fesm2022/ngxsmk-datepicker.mjs`
 
 Use with ESM-aware setups (e.g. Vite, import maps). Not for classic `<script>` tags.
 
@@ -58,7 +58,7 @@ Use with ESM-aware setups (e.g. Vite, import maps). Not for classic `<script>` t
 If a tarball is attached to a [GitHub Release](https://github.com/NGXSMK/ngxsmk-datepicker/releases), you can install it with:
 
 ```bash
-npm install https://github.com/NGXSMK/ngxsmk-datepicker/releases/download/v2.2.1/ngxsmk-datepicker-2.2.1.tgz
+npm install https://github.com/NGXSMK/ngxsmk-datepicker/releases/download/v2.2.2/ngxsmk-datepicker-2.2.2.tgz
 ```
 
 (Replace the version and URL with the actual release asset if provided.)

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -1,6 +1,6 @@
 # Performance Testing
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document outlines the performance testing infrastructure for the ngxsmk-datepicker library.
 

--- a/docs/RELATIVE_DATE_PARSING.md
+++ b/docs/RELATIVE_DATE_PARSING.md
@@ -1,6 +1,6 @@
 # 🧠 Relative Date Parsing Strategy
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document outlines the strategy for implementing Natural Language date entry (e.g., "next Friday", "in 2 weeks") in `ngxsmk-datepicker`.
 

--- a/docs/SIGNAL_FORMS_VALIDATION.md
+++ b/docs/SIGNAL_FORMS_VALIDATION.md
@@ -1,6 +1,6 @@
 # Angular Signal Forms Validation Support
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Overview
 

--- a/docs/VISUAL_REGRESSION_TESTING.md
+++ b/docs/VISUAL_REGRESSION_TESTING.md
@@ -1,6 +1,6 @@
 # Visual Regression Testing Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document describes the visual regression testing infrastructure for `ngxsmk-datepicker`, including screenshot-based testing for themes, layouts, and component states.
 

--- a/examples/angular-issue-test/README.md
+++ b/examples/angular-issue-test/README.md
@@ -1,6 +1,6 @@
 # ngxsmk-datepicker – Issue reproduction app
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 Minimal Angular app used to manually verify fixes for filed issues in `ngxsmk-datepicker`. The app consumes the library from the workspace (same as the main demo-app).
 

--- a/examples/material-integration/README.md
+++ b/examples/material-integration/README.md
@@ -14,10 +14,11 @@ because Angular's content-child resolution does not walk up to the parent's prov
 
 ## ✅ Recommended fix: directive
 
-Add **`ngxsmkMatFormFieldControl`** on the datepicker and import the directive. This works reliably with Vite and all bundlers (same token as `mat-form-field`).
+Add **`ngxsmkMatFormFieldControl`** on the datepicker and the directive. The directive is not in the main bundle; add the file from [INTEGRATION.md § Angular Material](../../projects/ngxsmk-datepicker/docs/INTEGRATION.md#angular-material) to your project, or (in this example) use the local copy under `src/app/`.
 
 ```typescript
-import { NgxsmkDatepickerComponent, NgxsmkDatepickerMatFormFieldControlDirective } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerComponent } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerMatFormFieldControlDirective } from './ngxsmk-mat-form-field.directive'; // local file
 import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({

--- a/examples/material-integration/src/app/ngxsmk-mat-form-field.directive.ts
+++ b/examples/material-integration/src/app/ngxsmk-mat-form-field.directive.ts
@@ -1,0 +1,12 @@
+import { Directive, forwardRef } from '@angular/core';
+import { MatFormFieldControl } from '@angular/material/form-field';
+import { NgxsmkDatepickerComponent } from 'ngxsmk-datepicker';
+
+@Directive({
+  selector: 'ngxsmk-datepicker[ngxsmkMatFormFieldControl]',
+  standalone: true,
+  providers: [
+    { provide: MatFormFieldControl, useExisting: forwardRef(() => NgxsmkDatepickerComponent) },
+  ],
+})
+export class NgxsmkDatepickerMatFormFieldControlDirective {}

--- a/examples/material-integration/src/main.ts
+++ b/examples/material-integration/src/main.ts
@@ -3,7 +3,8 @@ import { Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { NgxsmkDatepickerComponent, NgxsmkDatepickerMatFormFieldControlDirective } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerComponent } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerMatFormFieldControlDirective } from './app/ngxsmk-mat-form-field.directive';
 import { JsonPipe } from '@angular/common';
 
 @Component({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker-workspace",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {

--- a/projects/demo-app/src/app/i18n/translations.ts
+++ b/projects/demo-app/src/app/i18n/translations.ts
@@ -28,7 +28,7 @@ export const translations = {
       playground: 'Interactive Playground',
     },
     home: {
-      heroBadge: 'The #1 Angular DatePicker v2.2.1',
+      heroBadge: 'The #1 Angular DatePicker v2.2.2',
       heroTitle: 'The Premier Open-Source',
       heroSubtitle: 'Angular DatePicker',
       heroLead:
@@ -446,7 +446,7 @@ export const translations = {
       playground: 'Spielplatz',
     },
     home: {
-      heroBadge: 'Neu v2.2.1 Stabilität',
+      heroBadge: 'Neu v2.2.2 Stabilität',
       heroTitle: 'Der beste Open-Source',
       heroSubtitle: 'Angular DatePicker',
       heroLead:
@@ -868,7 +868,7 @@ export const translations = {
       playground: 'Laboratorio',
     },
     home: {
-      heroBadge: 'Nuevo v2.2.1 Estabilidad',
+      heroBadge: 'Nuevo v2.2.2 Estabilidad',
       heroTitle: 'El mejor Open-Source',
       heroSubtitle: 'Angular DatePicker',
       heroLead:
@@ -1289,7 +1289,7 @@ export const translations = {
       playground: 'Lekplats',
     },
     home: {
-      heroBadge: 'Ny v2.2.1 stabilitet',
+      heroBadge: 'Ny v2.2.2 stabilitet',
       heroTitle: 'Den bästa open-source',
       heroSubtitle: 'Angular datumväljare',
       heroLead:
@@ -1703,7 +1703,7 @@ export const translations = {
       playground: '플레이그라운드',
     },
     home: {
-      heroBadge: '새로운 v2.2.1 안정성',
+      heroBadge: '새로운 v2.2.2 안정성',
       heroTitle: '최고의 오픈 소스',
       heroSubtitle: 'Angular 데이트피커',
       heroLead:
@@ -2103,7 +2103,7 @@ export const translations = {
       playground: '演练场',
     },
     home: {
-      heroBadge: '全新 v2.2.1 稳定性',
+      heroBadge: '全新 v2.2.2 稳定性',
       heroTitle: '最佳开源',
       heroSubtitle: 'Angular 日期选择器',
       heroLead:
@@ -2490,7 +2490,7 @@ export const translations = {
       playground: 'プレイグラウンド',
     },
     home: {
-      heroBadge: '新しい v2.2.1 の安定性',
+      heroBadge: '新しい v2.2.2 の安定性',
       heroTitle: '最高のオープンソース',
       heroSubtitle: 'Angular デートピッカー',
       heroLead:
@@ -2895,7 +2895,7 @@ export const translations = {
       playground: 'Playground',
     },
     home: {
-      heroBadge: 'Nouvelle stabilité v2.2.1',
+      heroBadge: 'Nouvelle stabilité v2.2.2',
       heroTitle: 'Le meilleur Open-Source',
       heroSubtitle: 'Angular DatePicker',
       heroLead:

--- a/projects/demo-app/src/app/pages/home/home.component.ts
+++ b/projects/demo-app/src/app/pages/home/home.component.ts
@@ -113,7 +113,7 @@ import { I18nService } from '../../i18n/i18n.service';
               <div class="dot green"></div>
               <div class="window-title">terminal</div>
             </div>
-            <pre><code><span class="token-function">npm install</span> ngxsmk-datepicker@<span class="token-number">2.2.1</span></code></pre>
+            <pre><code><span class="token-function">npm install</span> ngxsmk-datepicker@<span class="token-number">2.2.2</span></code></pre>
           </div>
         </div>
       </section>

--- a/projects/demo-app/src/app/pages/installation/installation.component.ts
+++ b/projects/demo-app/src/app/pages/installation/installation.component.ts
@@ -21,7 +21,7 @@ import { I18nService } from '../../i18n/i18n.service';
           <div class="dot green"></div>
           <div class="window-title">bash</div>
         </div>
-        <pre><code class="text-main"><span class="token-function">npm install</span> ngxsmk-datepicker@<span class="token-number">2.2.1</span></code></pre>
+        <pre><code class="text-main"><span class="token-function">npm install</span> ngxsmk-datepicker@<span class="token-number">2.2.2</span></code></pre>
       </div>
 
       <div class="tip">
@@ -37,9 +37,9 @@ import { I18nService } from '../../i18n/i18n.service';
           <div class="dot green"></div>
           <div class="window-title">bash</div>
         </div>
-        <pre><code class="text-main"><span class="token-function">yarn add</span> ngxsmk-datepicker@<span class="token-number">2.2.1</span>
-<span class="token-function">pnpm add</span> ngxsmk-datepicker@<span class="token-number">2.2.1</span>
-<span class="token-function">bun add</span> ngxsmk-datepicker@<span class="token-number">2.2.1</span></code></pre>
+        <pre><code class="text-main"><span class="token-function">yarn add</span> ngxsmk-datepicker@<span class="token-number">2.2.2</span>
+<span class="token-function">pnpm add</span> ngxsmk-datepicker@<span class="token-number">2.2.2</span>
+<span class="token-function">bun add</span> ngxsmk-datepicker@<span class="token-number">2.2.2</span></code></pre>
       </div>
       <p>
         <a

--- a/projects/demo-app/src/app/pages/integrations/integrations.component.ts
+++ b/projects/demo-app/src/app/pages/integrations/integrations.component.ts
@@ -30,7 +30,8 @@ import type { DatepickerValue } from 'ngxsmk-datepicker';
           <div class="dot green"></div>
           <div class="window-title">my.component.ts</div>
         </div>
-        <pre><code class="text-main"><span class="token-keyword">import</span> {{ '{' }} <span class="token-class">NgxsmkDatepickerComponent</span>, <span class="token-class">NgxsmkDatepickerMatFormFieldControlDirective</span> {{ '}' }} <span class="token-keyword">from</span> <span class="token-string">'ngxsmk-datepicker'</span>;
+        <pre><code class="text-main"><span class="token-keyword">import</span> {{ '{' }} <span class="token-class">NgxsmkDatepickerComponent</span> {{ '}' }} <span class="token-keyword">from</span> <span class="token-string">'ngxsmk-datepicker'</span>;
+<span class="token-keyword">import</span> {{ '{' }} <span class="token-class">NgxsmkDatepickerMatFormFieldControlDirective</span> {{ '}' }} <span class="token-keyword">from</span> <span class="token-string">'./ngxsmk-mat-form-field.directive'</span>;
 <span class="token-keyword">import</span> {{ '{' }} <span class="token-class">MatFormFieldModule</span> {{ '}' }} <span class="token-keyword">from</span> <span class="token-string">'&#64;angular/material/form-field'</span>;
 
 <span class="token-keyword">&#64;Component</span>({{ '{' }}

--- a/projects/demo-app/src/index.html
+++ b/projects/demo-app/src/index.html
@@ -57,7 +57,7 @@
             "priceCurrency": "USD"
           },
           "description": "High-performance, Signal-based, and Zoneless datepicker library for Angular 17+ projects. Ranked #1 for speed and bundle size.",
-          "softwareVersion": "2.2.1",
+          "softwareVersion": "2.2.2",
           "license": "MIT",
           "aggregateRating": {
             "@type": "AggregateRating",

--- a/projects/ngxsmk-datepicker/README.md
+++ b/projects/ngxsmk-datepicker/README.md
@@ -24,15 +24,15 @@
 
 ---
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ### **Overview**
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.2.1` is live! This release brings a **TypeScript Strictness Overhaul** (eliminating `any` types and ensuring `exactOptionalPropertyTypes` compatibility), fixes **appendToBody** popover positioning, datepicker-in-modal first-open, and popover width matching the input; reduces loading time; and cleans up CSS. No breaking changes.
+> **Stable Release**: `v2.2.2` is live! This release brings a **TypeScript Strictness Overhaul** (eliminating `any` types and ensuring `exactOptionalPropertyTypes` compatibility), fixes **appendToBody** popover positioning, datepicker-in-modal first-open, and popover width matching the input; reduces loading time; and cleans up CSS. No breaking changes.
 >
-> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.2.1 or later.
+> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.2.2 or later.
 
 ---
 
@@ -330,22 +330,7 @@ export class MaterialFormComponent {
 }
 ```
 
-**Non-Standalone Components (NgModules):**
-
-```typescript
-import { NgModule } from "@angular/core";
-import { MatFormFieldControl } from "@angular/material/form-field";
-import { NgxsmkDatepickerComponent, provideMaterialFormFieldControl } from "ngxsmk-datepicker";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { MatInputModule } from "@angular/material/input";
-import { ReactiveFormsModule } from "@angular/forms";
-
-@NgModule({
-  imports: [NgxsmkDatepickerComponent, MatFormFieldModule, MatInputModule, ReactiveFormsModule],
-  providers: [provideMaterialFormFieldControl(MatFormFieldControl)],
-})
-export class MyModule {}
-```
+**Non-Standalone (NgModules):** Add the directive file from [INTEGRATION.md § Angular Material](docs/INTEGRATION.md#angular-material), then add it to your module `imports` (with `NgxsmkDatepickerComponent`, `MatFormFieldModule`, etc.) and use `ngxsmkMatFormFieldControl` on the datepicker in templates.
 
 **With Date Range:**
 
@@ -605,7 +590,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.2.1 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.2.2 now features **full localization synchronization** for:
 
 - 🇺🇸 English (`en`)
 - 🇩🇪 German (`de`)
@@ -698,7 +683,7 @@ This library has been optimized for maximum performance:
 
 ## **🐛 Bug Fixes & Improvements**
 
-### **Critical Updates in v2.2.1:**
+### **Critical Updates in v2.2.2:**
 
 - ✅ **Validation messages**: User-facing i18n strings for invalid date, min/max; `validationError` output and on-screen error display
 - ✅ **Calendar loading state**: Visual spinner + text and screen-reader announcement while calendar opens/generates
@@ -861,16 +846,16 @@ We welcome and appreciate contributions from the community! Whether it's reporti
 
 For a full list of changes, please refer to the [CHANGELOG.md](https://github.com/NGXSMK/ngxsmk-datepicker/blob/main/CHANGELOG.md) file.
 
-### **v2.2.1** (Current Stable)
+### **v2.2.2** (Current Stable)
 
-- 🎉 **Version Update**: Updated to version 2.2.1.
+- 🎉 **Version Update**: Updated to version 2.2.2.
 - ✨ **Key Updates**: Optimized loading times, refined mobile header layout, and improved dropdown accessibility.
 - ✅ **Stable Release**: Full synchronization of header components with `ViewEncapsulation.None`.
 
 ### **v1.9.24**
 
 - 🎉 **Version Update**: Updated to version 1.9.24
-- ✅ **Stable Release**: Version 1.9.24 is the current stable version
+- ✅ **Stable Release**: Version 2.2.2 is the current stable version
 
 ### **v1.9.23**
 

--- a/projects/ngxsmk-datepicker/docs/API.md
+++ b/projects/ngxsmk-datepicker/docs/API.md
@@ -2,7 +2,7 @@
 
 This document describes the stable public API of ngxsmk-datepicker with comprehensive real-world examples. APIs marked as **stable** are guaranteed to remain backward-compatible within the same major version. APIs marked as **experimental** may change in future releases.
 
-**Version**: 2.2.1+ | **Last updated**: March 3, 2026
+**Version**: 2.2.2+ | **Last updated**: March 3, 2026
 
 ## Stable vs experimental
 

--- a/projects/ngxsmk-datepicker/docs/COMPATIBILITY.md
+++ b/projects/ngxsmk-datepicker/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Version Compatibility Matrix
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document provides comprehensive compatibility information for `ngxsmk-datepicker` across different Angular versions, Zone.js configurations, and SSR/CSR setups.
 

--- a/projects/ngxsmk-datepicker/docs/INTEGRATION.md
+++ b/projects/ngxsmk-datepicker/docs/INTEGRATION.md
@@ -1,6 +1,6 @@
 # Integration Guides
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document provides integration examples for using ngxsmk-datepicker with popular frameworks and libraries.
 
@@ -37,6 +37,8 @@ The datepicker is built with **accessibility in mind**: keyboard navigation (arr
 
 ## Angular Material
 
+The main `ngxsmk-datepicker` bundle does **not** import `@angular/material`, so non-Material apps are not forced to install it. If you use `mat-form-field`, install Material and add the directive as below.
+
 ### Installation
 
 ```bash
@@ -45,10 +47,29 @@ npm install @angular/material @angular/cdk ngxsmk-datepicker
 
 ### Basic Integration (Standalone Components)
 
-**Default and recommended:** Use the **`ngxsmkMatFormFieldControl`** directive on the datepicker so `mat-form-field` finds it via `@ContentChild(MatFormFieldControl)`. No provider or `main.ts` setup required. Works with Vite and all bundlers. If you see "mat-form-field must contain a MatFormFieldControl", add the directive to the datepicker host (see Issue #187).
+**Recommended:** Use the **`ngxsmkMatFormFieldControl`** directive on the datepicker so `mat-form-field` finds it. Add this directive file to your project (e.g. `ngxsmk-mat-form-field.directive.ts`) so only Material apps pull in `@angular/material`:
 
 ```typescript
-import { NgxsmkDatepickerComponent, NgxsmkDatepickerMatFormFieldControlDirective } from 'ngxsmk-datepicker';
+// ngxsmk-mat-form-field.directive.ts
+import { Directive, forwardRef } from '@angular/core';
+import { MatFormFieldControl } from '@angular/material/form-field';
+import { NgxsmkDatepickerComponent } from 'ngxsmk-datepicker';
+
+@Directive({
+  selector: 'ngxsmk-datepicker[ngxsmkMatFormFieldControl]',
+  standalone: true,
+  providers: [
+    { provide: MatFormFieldControl, useExisting: forwardRef(() => NgxsmkDatepickerComponent) },
+  ],
+})
+export class NgxsmkDatepickerMatFormFieldControlDirective {}
+```
+
+Then in your component:
+
+```typescript
+import { NgxsmkDatepickerComponent } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerMatFormFieldControlDirective } from './ngxsmk-mat-form-field.directive'; // your local file
 import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
@@ -61,6 +82,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
   `
 })
 ```
+
+If you see "mat-form-field must contain a MatFormFieldControl", add the directive to the datepicker host (see Issue #187).
 
 **Alternative (legacy / when directive is not used):** In `main.ts` before bootstrap, call `NgxsmkDatepickerComponent.withMaterialSupport(MatFormFieldControl)` (and optionally set `globalThis.__NGXSMK_MAT_FORM_FIELD_CONTROL__ = MatFormFieldControl`). Then use the datepicker inside `mat-form-field` without the directive. Prefer the directive above.
 
@@ -114,12 +137,12 @@ export class DatepickerComponent {
 
 ### Integration with Non-Standalone Components (NgModules)
 
-For non-standalone components, you need to provide the Material form field control token using the `provideMaterialFormFieldControl` helper:
+Add the same directive file (see snippet above) to your project, then import it in your NgModule:
 
 ```typescript
 import { NgModule } from '@angular/core';
-import { MatFormFieldControl } from '@angular/material/form-field';
-import { NgxsmkDatepickerComponent, provideMaterialFormFieldControl } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerComponent } from 'ngxsmk-datepicker';
+import { NgxsmkDatepickerMatFormFieldControlDirective } from './ngxsmk-mat-form-field.directive'; // your local file
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -127,14 +150,16 @@ import { ReactiveFormsModule } from '@angular/forms';
 @NgModule({
   imports: [
     NgxsmkDatepickerComponent,
+    NgxsmkDatepickerMatFormFieldControlDirective,
     MatFormFieldModule,
     MatInputModule,
     ReactiveFormsModule
-  ],
-  providers: [provideMaterialFormFieldControl(MatFormFieldControl)]
+  ]
 })
 export class MyModule { }
 ```
+
+Use `ngxsmkMatFormFieldControl` on the datepicker in your templates.
 
 Then use it in your component:
 

--- a/projects/ngxsmk-datepicker/docs/IONIC_INTEGRATION.md
+++ b/projects/ngxsmk-datepicker/docs/IONIC_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Ionic Framework Integration Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This guide provides step-by-step instructions for integrating ngxsmk-datepicker with Ionic Angular applications.
 

--- a/projects/ngxsmk-datepicker/docs/IONIC_TESTING.md
+++ b/projects/ngxsmk-datepicker/docs/IONIC_TESTING.md
@@ -1,6 +1,6 @@
 # Ionic Integration Testing Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document provides comprehensive testing instructions for verifying ngxsmk-datepicker compatibility with Ionic Framework.
 

--- a/projects/ngxsmk-datepicker/docs/LOCALE-GUIDE.md
+++ b/projects/ngxsmk-datepicker/docs/LOCALE-GUIDE.md
@@ -1,6 +1,6 @@
 # Locale Packs & i18n Contributor Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 Guide for adding locale support and contributing translations to ngxsmk-datepicker.
 

--- a/projects/ngxsmk-datepicker/docs/PLUGIN-ARCHITECTURE.md
+++ b/projects/ngxsmk-datepicker/docs/PLUGIN-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Plugin Architecture
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ngxsmk-datepicker features a powerful **plugin architecture** that allows you to extend and customize the component's behavior without modifying its core code. This architecture is built on a **hook-based system** that provides extension points throughout the component's lifecycle.
 

--- a/projects/ngxsmk-datepicker/docs/SEO.md
+++ b/projects/ngxsmk-datepicker/docs/SEO.md
@@ -1,6 +1,6 @@
 # SEO Optimization Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This document outlines the SEO optimizations implemented for ngxsmk-datepicker to improve search engine visibility and discoverability.
 

--- a/projects/ngxsmk-datepicker/docs/SSR-EXAMPLE.md
+++ b/projects/ngxsmk-datepicker/docs/SSR-EXAMPLE.md
@@ -1,6 +1,6 @@
 # Server-Side Rendering (SSR) Example
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 Complete example demonstrating ngxsmk-datepicker with Angular Universal (SSR).
 

--- a/projects/ngxsmk-datepicker/docs/THEME-TOKENS.md
+++ b/projects/ngxsmk-datepicker/docs/THEME-TOKENS.md
@@ -1,6 +1,6 @@
 # Theme Tokens & CSS Custom Properties
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 Complete reference for all CSS custom properties (CSS variables) available in ngxsmk-datepicker.
 

--- a/projects/ngxsmk-datepicker/docs/TIMEZONE.md
+++ b/projects/ngxsmk-datepicker/docs/TIMEZONE.md
@@ -1,6 +1,6 @@
 # Timezone Support
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ## Overview
 

--- a/projects/ngxsmk-datepicker/docs/extension-points.md
+++ b/projects/ngxsmk-datepicker/docs/extension-points.md
@@ -1,6 +1,6 @@
 # Extension Points and Hooks
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ngxsmk-datepicker provides comprehensive extension points through the `hooks` input, allowing you to customize rendering, validation, keyboard shortcuts, formatting, and event handling.
 

--- a/projects/ngxsmk-datepicker/docs/signal-forms.md
+++ b/projects/ngxsmk-datepicker/docs/signal-forms.md
@@ -1,6 +1,6 @@
 # Signal Forms Integration
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 This guide covers using ngxsmk-datepicker with Angular 21+ Signal Forms API.
 

--- a/projects/ngxsmk-datepicker/docs/signals.md
+++ b/projects/ngxsmk-datepicker/docs/signals.md
@@ -1,6 +1,6 @@
 # Signals Integration Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ngxsmk-datepicker is fully compatible with Angular Signals, providing seamless integration with both traditional reactive forms and modern signal-based patterns.
 

--- a/projects/ngxsmk-datepicker/docs/ssr.md
+++ b/projects/ngxsmk-datepicker/docs/ssr.md
@@ -1,6 +1,6 @@
 # Server-Side Rendering (SSR) Guide
 
-**Last updated:** March 3, 2026 · **Current stable:** v2.2.1
+**Last updated:** March 3, 2026 · **Current stable:** v2.2.2
 
 ngxsmk-datepicker is fully compatible with Angular Universal and server-side rendering. This guide covers SSR setup, best practices, and troubleshooting.
 

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.linkedin.com/in/sachindilshan/"

--- a/projects/ngxsmk-datepicker/src/public-api.ts
+++ b/projects/ngxsmk-datepicker/src/public-api.ts
@@ -106,5 +106,6 @@ export { HapticFeedbackService } from './lib/services/haptic-feedback.service';
 export { FieldSyncService } from './lib/services/field-sync.service';
 export type { SignalFormField, SignalFormFieldConfig } from './lib/services/field-sync.service';
 
-export { provideMaterialFormFieldControl } from './lib/material-form-field.helper';
-export { NgxsmkDatepickerMatFormFieldControlDirective } from './lib/material-form-field.directive';
+// Material (mat-form-field) integration is optional. The main bundle does not import @angular/material.
+// To use with mat-form-field: install @angular/material and @angular/cdk, then add the directive
+// from the repo or use the snippet in INTEGRATION.md § Angular Material.


### PR DESCRIPTION
chore(release): bump to 2.2.2

- Set version in root and lib package.json
- Add [2.2.2] to CHANGELOG
- Update "Current stable" and install/CDN examples in README and docs
- Update demo-app and translations to v2.2.2