### PR TITLE
fix(release): publish-ready v2.2.13 with tarball validation and docs/version alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      # Fail fast if ng-packagr output cannot be produced (avoids publishing docs-only tarballs).
+      - run: npm run build:optimized && npm run prepublish:copy-assets && node scripts/assert-dist-lib-ready.cjs && npm run verify:dist-tarball
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,7 +22,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm run build:optimized && npm run prepublish:copy-assets && node scripts/assert-dist-lib-ready.cjs"
+        "prepareCmd": "npm run build:optimized && npm run prepublish:copy-assets && node scripts/assert-dist-lib-ready.cjs && npm run verify:dist-tarball"
       }
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased]`r`n`r`n## [2.2.13] - 2026-05-06`r`n`r`n### Fixed`r`n`r`n- **npm package**: Republished with complete build artifacts (`fesm2022/`, `types/`) and release safeguards to prevent docs-only tarballs.`r`n
 
 ### Added
 
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Roadmap**: Updated main-component line count reference; roadmap links now resolve to `IMPROVEMENT_REPORT.md`.
 - **Compatibility Docs**: Clarified Vitest wording to describe compatibility without implying a default test runner requirement.
 - **i18n (demo)**: New playground strings for the Advanced section (all demo-app languages).
+
+## [2.2.12] - 2026-05-02 [BROKEN - NPM PACKAGE]
+
+### Fixed
+
+- **npm package**: The `2.2.12` tarball on the registry omitted `fesm2022/` and `types/` (only docs, styles, and package metadata). **Use `ngxsmk-datepicker@2.2.11` until `2.2.13` or later** with a full ng-packagr build ([#230](https://github.com/NGXSMK/ngxsmk-datepicker/issues/230)).
 
 ## [2.2.11] - 2026-03-24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to ngxsmk-datepicker! This document provides guidelines and instructions for contributing.
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Code of Conduct
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 This document explains how the ngxsmk-datepicker demo app is deployed to GitHub Pages.
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Automatic Deployment
 

--- a/IMPROVEMENT_REPORT.md
+++ b/IMPROVEMENT_REPORT.md
@@ -1,6 +1,6 @@
 # Comprehensive Improvement Report
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document is the **maintained index** for architectural and quality initiatives referenced from [ROADMAP.md](ROADMAP.md). Each section maps to anchor links used across the repository. Effort levels: **S** small, **M** medium, **L** large.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This document provides migration instructions for upgrading between major versions of ngxsmk-datepicker.
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Table of Contents
 
@@ -58,6 +58,14 @@ This document provides migration instructions for upgrading between major versio
 - [v1.8.0 → v1.9.0](#v180---v190)
 - [v1.7.0 → v1.8.0](#v170---v180)
 
+## npm: skip v2.2.12
+
+The **`2.2.12`** package on the registry is missing **`fesm2022/`** and **`types/`**. Stay on **`2.2.11`** or upgrade to **`2.2.13`** (or newer) once published ([#230](https://github.com/NGXSMK/ngxsmk-datepicker/issues/230)).
+
+```bash
+npm install ngxsmk-datepicker@2.2.13
+```
+
 ## v2.2.7 → v2.2.11
 
 ### Changes
@@ -69,7 +77,7 @@ This document provides migration instructions for upgrading between major versio
 No breaking changes.
 
 ```bash
-npm install ngxsmk-datepicker@2.2.11
+npm install ngxsmk-datepicker@2.2.13
 ```
 
 ## v2.2.6 → v2.2.7
@@ -84,7 +92,7 @@ npm install ngxsmk-datepicker@2.2.11
 No breaking changes. Use **2.2.11** on npm (the `2.2.7` npm package was incomplete; 2.2.11 matches the intended 2.2.7 release).
 
 ```bash
-npm install ngxsmk-datepicker@2.2.11
+npm install ngxsmk-datepicker@2.2.13
 ```
 
 ## v2.2.3 → v2.2.6
@@ -313,7 +321,6 @@ npm install ngxsmk-datepicker@2.0.8
 ### Changes
 
 - **Version Update**: Updated to version 2.0.7
-- **Stable Release**: Version 2.2.12 is the current stable version
 - No breaking changes.
 
 ### Migration Steps

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 This document outlines the process for publishing new versions of `ngxsmk-datepicker` to npm.
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Prerequisites
 
@@ -104,8 +104,8 @@ npm run publish:beta
 ### 2. Publish production (after beta is validated)
 
 ```bash
-# Set the stable version (must match the release, e.g. 2.2.12 from 2.2.12-beta.0)
-npm run version:stable -- 2.2.12
+# Set the stable version (must match the release, e.g. 2.2.13 from 2.2.13-beta.0)
+npm run version:stable -- 2.2.13
 
 # Update CHANGELOG.md: rename [X.Y.Z-beta.N] to [X.Y.Z] or add a [X.Y.Z] section, then commit
 
@@ -113,13 +113,13 @@ npm run version:stable -- 2.2.12
 npm run publish:patch
 ```
 
-- Users on `ngxsmk-datepicker@latest` (or `ngxsmk-datepicker`) will get the latest stable (e.g. 2.2.12)
+- Users on `ngxsmk-datepicker@latest` (or `ngxsmk-datepicker`) will get the latest stable (e.g. 2.2.13)
 - Users on `ngxsmk-datepicker@beta` will continue to get the latest beta until you publish a new one
 
 ### Manual version (optional)
 
-- Set a specific beta: `node scripts/set-beta-version.js 2.2.12-beta.0`
-- Set stable: `node scripts/set-stable-version.js 2.2.12`
+- Set a specific beta: `node scripts/set-beta-version.js 2.2.13-beta.0`
+- Set stable: `node scripts/set-stable-version.js 2.2.13`
 
 ## Pre-Release Checklist
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@
 
 ---
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ### **Overview**
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.2.12` restores correct **npm** artifacts (compiled `fesm2022/` and types), adds range-mode **`allowSameDay`** for single-day selections, and continues to ship **IANA timezone** support, validation fixes, and strict TypeScript improvements from the v2.2.x line.
+> **Stable Release**: `v2.2.13` is the current stable release with compiled `fesm2022` output and type declarations.
 >
-> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.2.12 or later.
+> **Stable line**: v2.2.x includes range-mode **`allowSameDay`**, **IANA timezone** support, validation fixes, and strict TypeScript improvements. Versions **2.0.10** and **2.0.11** were broken and have been **unpublished**; use **v2.1.1+** or current **v2.2.13** on npm.
 
 ---
 
@@ -140,7 +140,7 @@ For details, see [CONTRIBUTING.md](https://github.com/NGXSMK/ngxsmk-datepicker/b
 ## **📦 Installation**
 
 ```bash
-npm install ngxsmk-datepicker@2.2.12
+npm install ngxsmk-datepicker@2.2.13
 ```
 
 ### Alternative installation
@@ -149,12 +149,12 @@ You can install without npm using any of these methods (peer dependencies must s
 
 | Method | Command |
 |--------|--------|
-| **Yarn** | `yarn add ngxsmk-datepicker@2.2.12` |
-| **pnpm** | `pnpm add ngxsmk-datepicker@2.2.12` |
-| **Bun** | `bun add ngxsmk-datepicker@2.2.12` |
-| **From Git** | `npm install github:NGXSMK/ngxsmk-datepicker#v2.2.12` (requires the repo to have built output or you build from source) |
+| **Yarn** | `yarn add ngxsmk-datepicker@2.2.13` |
+| **pnpm** | `pnpm add ngxsmk-datepicker@2.2.13` |
+| **Bun** | `bun add ngxsmk-datepicker@2.2.13` |
+| **From Git** | `npm install github:NGXSMK/ngxsmk-datepicker#v2.2.13` (requires the repo to have built output or you build from source) |
 | **Local path** | Build the library in the repo (`npx ng build ngxsmk-datepicker`), then `npm install /path/to/ngxsmk-datepicker/dist/ngxsmk-datepicker` |
-| **CDN (ESM)** | Use [unpkg](https://unpkg.com/ngxsmk-datepicker@2.2.12/) or [jsDelivr](https://cdn.jsdelivr.net/npm/ngxsmk-datepicker@2.2.12/) in your bundler or import map; peer dependencies (Angular, etc.) must be installed in your app. |
+| **CDN (ESM)** | Use [unpkg](https://unpkg.com/ngxsmk-datepicker@2.2.13/) or [jsDelivr](https://cdn.jsdelivr.net/npm/ngxsmk-datepicker@2.2.13/) in your bundler or import map; peer dependencies (Angular, etc.) must be installed in your app. |
 
 For all options and caveats, see [docs/INSTALLATION.md](docs/INSTALLATION.md).
 
@@ -605,7 +605,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.2.12 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.2.x now features **full localization synchronization** for:
 
 - �� English (`en`)
 - �� German (`de`)
@@ -865,7 +865,7 @@ We welcome and appreciate contributions from the community! Whether it's reporti
 
 ## **📄 Changelog**
 
-**Recent:** v2.2.12 — npm publish pipeline fix (full `fesm2022`/types), `allowSameDay` range mode, plus TypeScript strictness, appendToBody/popover fixes, and CSS cleanup from v2.2.x. Versions 2.0.10 and 2.0.11 are unpublished; use v2.2.12 or later.
+**Recent:** Use **v2.2.13** on npm. The v2.2.x line adds `allowSameDay` range mode, IANA timezone support, TypeScript strictness, appendToBody/popover fixes, and CSS cleanup. Versions 2.0.10 and 2.0.11 are unpublished; use v2.1.1+ or **v2.2.13**.
 
 For the full list of changes, see [CHANGELOG.md](https://github.com/NGXSMK/ngxsmk-datepicker/blob/main/CHANGELOG.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap outlines the planned features, improvements, and enhancements for ngxsmk-datepicker. We welcome community input and contributions!
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## 🎯 Current Focus (Q1 2026 - Q2 2026)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Supported Versions
 

--- a/docs/ACCESSIBILITY_TESTING.md
+++ b/docs/ACCESSIBILITY_TESTING.md
@@ -1,6 +1,6 @@
 # Accessibility Testing
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document outlines the accessibility testing infrastructure integrated into the ngxsmk-datepicker library.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 Complete API reference for ngxsmk-datepicker with JSDoc examples for improved IDE IntelliSense.
 
-**Version**: 2.2.12+  
+**Version**: 2.2.13+  
 **Last Updated**: March 10, 2026
 
 ---

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation options for ngxsmk-datepicker
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document lists all supported ways to install `ngxsmk-datepicker` in your Angular project. The package is published to the npm registry and can also be installed via other package managers, from Git, from a local path, or via CDN (ESM).
 

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -1,6 +1,6 @@
 # Performance Testing
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document outlines the performance testing infrastructure for the ngxsmk-datepicker library.
 

--- a/docs/RELATIVE_DATE_PARSING.md
+++ b/docs/RELATIVE_DATE_PARSING.md
@@ -1,6 +1,6 @@
 # 🧠 Relative Date Parsing Strategy
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document outlines the strategy for implementing Natural Language date entry (e.g., "next Friday", "in 2 weeks") in `ngxsmk-datepicker`.
 

--- a/docs/SIGNAL_FORMS_VALIDATION.md
+++ b/docs/SIGNAL_FORMS_VALIDATION.md
@@ -1,6 +1,6 @@
 # Angular Signal Forms Validation Support
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Overview
 

--- a/docs/VISUAL_REGRESSION_TESTING.md
+++ b/docs/VISUAL_REGRESSION_TESTING.md
@@ -1,6 +1,6 @@
 # Visual Regression Testing Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document describes the visual regression testing infrastructure for `ngxsmk-datepicker`, including screenshot-based testing for themes, layouts, and component states.
 

--- a/examples/angular-issue-test/README.md
+++ b/examples/angular-issue-test/README.md
@@ -1,6 +1,6 @@
 # ngxsmk-datepicker – Issue reproduction app
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 Minimal Angular app used to manually verify fixes for filed issues in `ngxsmk-datepicker`. The app consumes the library from the workspace (same as the main demo-app).
 

--- a/examples/ionic-test-app/package.json
+++ b/examples/ionic-test-app/package.json
@@ -28,7 +28,7 @@
     "@capacitor/status-bar": "^8.0.2",
     "@ionic/angular": "^8.8.5",
     "ionicons": "^8.0.13",
-    "ngxsmk-datepicker": "^2.2.12",
+    "ngxsmk-datepicker": "^2.2.13",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "~0.15.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker-workspace",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "A lightweight, customizable, and easy-to-use datepicker and date range picker for Angular applications.",
   "license": "MIT",
   "engines": {
@@ -28,8 +28,9 @@
     "unpublish:version": "node scripts/unpublish-version.js",
     "version:beta": "node scripts/set-beta-version.js next",
     "version:stable": "node scripts/set-stable-version.js",
-    "publish:beta": "npm run build:optimized && npm run prepublish:copy-assets && cd dist/ngxsmk-datepicker && npm publish --tag beta",
-    "publish:patch": "npm run build:optimized && npm run prepublish:copy-assets && cd dist/ngxsmk-datepicker && npm publish --tag latest",
+    "verify:dist-tarball": "node scripts/verify-dist-tarball.cjs",
+    "publish:beta": "npm run build:optimized && npm run prepublish:copy-assets && npm run verify:dist-tarball && cd dist/ngxsmk-datepicker && npm publish --tag beta",
+    "publish:patch": "npm run build:optimized && npm run prepublish:copy-assets && npm run verify:dist-tarball && cd dist/ngxsmk-datepicker && npm publish --tag latest",
     "semantic-release": "semantic-release",
     "docs": "typedoc --options typedoc.json && node scripts/enhance-api-docs.js",
     "docs:serve": "npm run docs && npx http-server docs/api -p 8080 -o",

--- a/projects/ngxsmk-datepicker/README.md
+++ b/projects/ngxsmk-datepicker/README.md
@@ -25,15 +25,15 @@
 
 ---
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ### **Overview**
 
 **ngxsmk-datepicker** is a high-performance, enterprise-ready date and range picker engineered for the modern Angular ecosystem (v17+). Built from the ground up with **Angular Signals**, it delivers a seamless, zoneless-ready experience for both desktop and mobile (Ionic) applications.
 
-> **Stable Release**: `v2.2.12` restores correct **npm** artifacts (compiled `fesm2022/` and types), adds range-mode **`allowSameDay`** for single-day selections, and continues to ship **IANA timezone** support, validation fixes, and strict TypeScript improvements from the v2.2.x line.
+> **Stable Release**: `v2.2.13` is the current stable release with compiled `fesm2022` output and type declarations.
 >
-> ⚠️ **Important**: Versions 2.0.10 and 2.0.11 are broken and have been unpublished. Please use v2.2.12 or later.
+> **Stable line**: v2.2.x includes **`allowSameDay`**, **IANA timezone** support, validation fixes, and strict TypeScript improvements. Versions **2.0.10** and **2.0.11** were **unpublished**; use **v2.1.1+** or **v2.2.13** on npm.
 
 ---
 
@@ -591,7 +591,7 @@ The `locale` input controls all internationalization. It automatically formats m
 
 ### **Global Language Support**
 
-ngxsmk-datepicker v2.2.12 now features **full localization synchronization** for:
+ngxsmk-datepicker v2.2.x now features **full localization synchronization** for:
 
 - 🇺🇸 English (`en`)
 - 🇩🇪 German (`de`)
@@ -850,12 +850,7 @@ We welcome and appreciate contributions from the community! Whether it's reporti
 
 For a full list of changes, please refer to the [CHANGELOG.md](https://github.com/NGXSMK/ngxsmk-datepicker/blob/main/CHANGELOG.md) file.
 
-### **v2.2.12** (Current Stable)
-
-- 🎉 **Version Update**: Updated to version 2.2.12.
-- 📦 **npm**: Published tarballs again include `fesm2022/` and TypeScript declarations (release pipeline runs `ng build` before publish).
-- 📅 **Range mode**: Optional `allowSameDay` for single-day ranges (double-click same date or close popover after one day).
-- ✅ **Prior fixes**: IANA timezone “Today”, `minDate` normalization, strict typings, and UI polish from v2.2.6 remain included.
+### **v2.2.13** (Current Stable)`r`n`r`n- **npm**: Published tarballs include compiled `fesm2022/` output and type declarations.
 
 ### **Earlier Versions**
 

--- a/projects/ngxsmk-datepicker/docs/API.md
+++ b/projects/ngxsmk-datepicker/docs/API.md
@@ -2,7 +2,7 @@
 
 This document describes the stable public API of ngxsmk-datepicker with comprehensive real-world examples. APIs marked as **stable** are guaranteed to remain backward-compatible within the same major version. APIs marked as **experimental** may change in future releases.
 
-**Version**: 2.2.12+ | **Last updated**: March 21, 2026
+**Version**: 2.2.13+ | **Last updated**: March 21, 2026
 
 ## Stable vs experimental
 

--- a/projects/ngxsmk-datepicker/docs/COMPATIBILITY.md
+++ b/projects/ngxsmk-datepicker/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Version Compatibility Matrix
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document provides comprehensive compatibility information for `ngxsmk-datepicker` across different Angular versions, Zone.js configurations, and SSR/CSR setups.
 

--- a/projects/ngxsmk-datepicker/docs/INTEGRATION.md
+++ b/projects/ngxsmk-datepicker/docs/INTEGRATION.md
@@ -1,6 +1,6 @@
 # Integration Guides
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document provides integration examples for using ngxsmk-datepicker with popular frameworks and libraries.
 

--- a/projects/ngxsmk-datepicker/docs/IONIC_INTEGRATION.md
+++ b/projects/ngxsmk-datepicker/docs/IONIC_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Ionic Framework Integration Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This guide provides step-by-step instructions for integrating ngxsmk-datepicker with Ionic Angular applications.
 

--- a/projects/ngxsmk-datepicker/docs/IONIC_TESTING.md
+++ b/projects/ngxsmk-datepicker/docs/IONIC_TESTING.md
@@ -1,6 +1,6 @@
 # Ionic Integration Testing Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document provides comprehensive testing instructions for verifying ngxsmk-datepicker compatibility with Ionic Framework.
 

--- a/projects/ngxsmk-datepicker/docs/LOCALE-GUIDE.md
+++ b/projects/ngxsmk-datepicker/docs/LOCALE-GUIDE.md
@@ -1,6 +1,6 @@
 # Locale Packs & i18n Contributor Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 Guide for adding locale support and contributing translations to ngxsmk-datepicker.
 

--- a/projects/ngxsmk-datepicker/docs/PLUGIN-ARCHITECTURE.md
+++ b/projects/ngxsmk-datepicker/docs/PLUGIN-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Plugin Architecture
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ngxsmk-datepicker features a powerful **plugin architecture** that allows you to extend and customize the component's behavior without modifying its core code. This architecture is built on a **hook-based system** that provides extension points throughout the component's lifecycle.
 

--- a/projects/ngxsmk-datepicker/docs/SEO.md
+++ b/projects/ngxsmk-datepicker/docs/SEO.md
@@ -1,6 +1,6 @@
 # SEO Optimization Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This document outlines the SEO optimizations implemented for ngxsmk-datepicker to improve search engine visibility and discoverability.
 

--- a/projects/ngxsmk-datepicker/docs/SSR-EXAMPLE.md
+++ b/projects/ngxsmk-datepicker/docs/SSR-EXAMPLE.md
@@ -1,6 +1,6 @@
 # Server-Side Rendering (SSR) Example
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 Complete example demonstrating ngxsmk-datepicker with Angular Universal (SSR).
 

--- a/projects/ngxsmk-datepicker/docs/THEME-TOKENS.md
+++ b/projects/ngxsmk-datepicker/docs/THEME-TOKENS.md
@@ -1,6 +1,6 @@
 # Theme Tokens & CSS Custom Properties
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 Complete reference for all CSS custom properties (CSS variables) available in ngxsmk-datepicker.
 

--- a/projects/ngxsmk-datepicker/docs/TIMEZONE.md
+++ b/projects/ngxsmk-datepicker/docs/TIMEZONE.md
@@ -1,6 +1,6 @@
 # Timezone Support
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ## Overview
 

--- a/projects/ngxsmk-datepicker/docs/extension-points.md
+++ b/projects/ngxsmk-datepicker/docs/extension-points.md
@@ -1,6 +1,6 @@
 # Extension Points and Hooks
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ngxsmk-datepicker provides comprehensive extension points through the `hooks` input, allowing you to customize rendering, validation, keyboard shortcuts, formatting, and event handling.
 

--- a/projects/ngxsmk-datepicker/docs/signal-forms.md
+++ b/projects/ngxsmk-datepicker/docs/signal-forms.md
@@ -1,6 +1,6 @@
 # Signal Forms Integration
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 This guide covers using ngxsmk-datepicker with Angular 21+ Signal Forms API.
 

--- a/projects/ngxsmk-datepicker/docs/signals.md
+++ b/projects/ngxsmk-datepicker/docs/signals.md
@@ -1,6 +1,6 @@
 # Signals Integration Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ngxsmk-datepicker is fully compatible with Angular Signals, providing seamless integration with both traditional reactive forms and modern signal-based patterns.
 

--- a/projects/ngxsmk-datepicker/docs/ssr.md
+++ b/projects/ngxsmk-datepicker/docs/ssr.md
@@ -1,6 +1,6 @@
 # Server-Side Rendering (SSR) Guide
 
-**Last updated:** May 2, 2026 · **Current stable:** v2.2.12
+**Last updated:** May 6, 2026 - **Current stable:** v2.2.13
 
 ngxsmk-datepicker is fully compatible with Angular Universal and server-side rendering. This guide covers SSR setup, best practices, and troubleshooting.
 

--- a/projects/ngxsmk-datepicker/package.json
+++ b/projects/ngxsmk-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-datepicker",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "author": {
     "name": "Sachin Dilshan",
     "url": "https://www.sachindilshan.com/"
@@ -80,11 +80,6 @@
   },
   "prepublishOnly": "node ../../scripts/assert-lib-publish-artifacts.cjs",
   "exports": {
-    ".": {
-      "types": "./types/ngxsmk-datepicker.d.ts",
-      "import": "./fesm2022/ngxsmk-datepicker.mjs",
-      "default": "./fesm2022/ngxsmk-datepicker.mjs"
-    },
     "./styles/*": {
       "default": "./styles/*"
     }

--- a/scripts/verify-dist-tarball.cjs
+++ b/scripts/verify-dist-tarball.cjs
@@ -1,0 +1,46 @@
+ 'use strict';
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+ const repoRoot = path.join(__dirname, '..');
+ const distRoot = path.join(repoRoot, 'dist', 'ngxsmk-datepicker');
+
+ function run(command) {
+   return execSync(command, { cwd: repoRoot, encoding: 'utf8' }).trim();
+ }
+
+ if (!fs.existsSync(distRoot)) {
+   console.error('[verify-dist-tarball] Missing dist package folder:', distRoot);
+   console.error('[verify-dist-tarball] Run: npm run build:optimized && npm run prepublish:copy-assets');
+   process.exit(1);
+ }
+
+ const tgzName = run('npm pack "./dist/ngxsmk-datepicker" --silent').split('\n').pop();
+ const tgzPath = path.join(repoRoot, tgzName);
+
+ if (!fs.existsSync(tgzPath)) {
+   console.error('[verify-dist-tarball] npm pack did not produce expected tarball:', tgzPath);
+   process.exit(1);
+ }
+
+ const listing = run(`tar -tzf "${tgzPath}"`);
+ const requiredEntries = ['package/fesm2022/ngxsmk-datepicker.mjs', 'package/types/ngxsmk-datepicker.d.ts'];
+
+ let ok = true;
+ for (const required of requiredEntries) {
+   if (!listing.includes(required)) {
+     console.error('[verify-dist-tarball] Missing tarball entry:', required);
+     ok = false;
+   }
+ }
+
+ fs.unlinkSync(tgzPath);
+
+ if (!ok) {
+   console.error('[verify-dist-tarball] Tarball validation failed.');
+   process.exit(1);
+ }
+
+ console.log('[verify-dist-tarball] Tarball contains required compiled outputs.');


### PR DESCRIPTION
## Summary

This PR prepares **v2.2.13** as the next stable release after the broken `2.2.12` npm package, and hardens the release pipeline so incomplete tarballs cannot be published again.

## What changed

- Added a new publish guard script: `scripts/verify-dist-tarball.cjs`
  - Packs `dist/ngxsmk-datepicker`
  - Validates required compiled outputs exist in the tarball:
    - `package/fesm2022/ngxsmk-datepicker.mjs`
    - `package/types/ngxsmk-datepicker.d.ts`
- Wired tarball verification into release flows:
  - `package.json` (`verify:dist-tarball`, `publish:beta`, `publish:patch`)
  - `.releaserc.json` (`prepareCmd`)
  - `.github/workflows/release.yml` (pre-semantic-release guard step)
- Removed conflicting `exports["."]` from `projects/ngxsmk-datepicker/package.json` to eliminate ng-packagr warnings.
- Updated versions to **2.2.13** in root and library package manifests.
- Updated markdown/docs to reflect **current stable v2.2.13** and aligned release/publishing guidance.
- Updated `examples/ionic-test-app/package.json` to consume `^2.2.13`.

## Why

- Fixes the root cause behind `ts(2307)` for consumers installing `latest` when compiled outputs are missing.
- Prevents recurrence of docs-only/incomplete npm tarballs.
- Aligns docs, release notes, and install guidance with the intended stable version.

## Beta testing plan

Before stable publish, release a beta build for verification:

- `node scripts/set-beta-version.js 2.2.13-beta.0`
- `npm run publish:beta`

Then finalize stable:

- `node scripts/set-stable-version.js 2.2.13`
- `npm run publish:patch`

## Verification

- `npm run build:optimized` succeeds
- `npm run verify:dist-tarball` passes and confirms required compiled entries are present in packed output
